### PR TITLE
chore(build): activate github workflows

### DIFF
--- a/.github/workflows/ante-benchmark.yml
+++ b/.github/workflows/ante-benchmark.yml
@@ -3,12 +3,16 @@ name: AnteHandler Benchmark Tests
 on:
   push:
     branches:
+      - develop
       - main
+      - master
     paths: 
       - 'app/ante/**'
   pull_request:
     branches:
+      - develop
       - main
+      - master
     paths: 
       - 'app/ante/**'
 
@@ -22,7 +26,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: '1.21'
           check-latest: true
 
       - name: Run benchmark tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,24 +2,23 @@ name: Build
 on:
   pull_request:
     branches:
+      - develop
       - main
+      - master
+
+# Automatically cancel run if another commit to the same ref is detected.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  cleanup-runs:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: rokroskar/workflow-run-cleanup-action@master
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-    if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/main'"
-
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: '1.21'
           check-latest: true
       - uses: technote-space/get-diff-action@v6.1.2
         id: git_diff

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,10 +13,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [main]
+    branches: [develop, main, master]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [main]
+    branches: [develop, main, master]
   schedule:
     - cron: '37 21 * * 4'
 

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: '1.21'
           check-latest: true
       - name: "Checkout Repository"
         uses: actions/checkout@v4

--- a/.github/workflows/e2e-test-release.yml
+++ b/.github/workflows/e2e-test-release.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: '1.21'
           check-latest: true
       - uses: actions/checkout@v4
       - name: Test E2E

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -2,10 +2,14 @@ name: E2E Test
 on:
   pull_request:
     branches:
+      - develop
       - main
+      - master
   push:
     branches:
+      - develop
       - main
+      - master
 
 jobs:
   test-e2e:
@@ -13,7 +17,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: '1.21'
           check-latest: true
       - uses: actions/checkout@v4
       - uses: technote-space/get-diff-action@v6.1.2

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: '1.21'
           check-latest: true
       - name: release dry run
         run: make release-dry-run

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -11,6 +11,6 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v4
-      with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+      - uses: actions/labeler@v4
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -3,7 +3,9 @@ on:
   pull_request:
   push:
     branches:
+      - develop
       - main
+      - master
 
 jobs:
   triage:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,5 @@
 name: Lint
-# Lint runs golangci-lint over the entire exocore repository This workflow is
-# run on every pull request and push to main The `golangci` will pass without
+# Lint runs golangci-lint over the entire exocore repository. The `golangci` will pass without
 # running if no *.{go, mod, sum} files have been changed.
 on:
   pull_request:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,7 +6,13 @@ on:
   pull_request:
   push:
     branches:
+      - develop
       - main
+      - master
+
+permissions:
+  contents: read
+
 jobs:
   golangci:
     name: Run golangci-lint
@@ -14,20 +20,25 @@ jobs:
     timeout-minutes: 10
     steps:
       # Required: setup-go, for all versions v3.0.0+ of golangci-lint
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
-          go-version: '1.20'
-          check-latest: true
+          go-version: '1.21'
+          # Use pinned versions, not git versions
+          check-latest: false
+          # Match `golangci-lint-action` recommendation
+          cache: false
       - uses: actions/checkout@v4
+      # Only operate if there are any differences in go files
       - uses: technote-space/get-diff-action@v6.1.2
         with:
           PATTERNS: |
             **/**.go
             go.mod
             go.sum
-      - uses: golangci/golangci-lint-action@v3.7.0
+      # Now, the actual golangci-lint configuration
+      - uses: golangci/golangci-lint-action@v4
         with:
-          # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
+          # Required parameter
           version: latest
           args: --timeout 10m
           github-token: ${{ secrets.github_token }}

--- a/.github/workflows/markdown-links.yml
+++ b/.github/workflows/markdown-links.yml
@@ -5,7 +5,9 @@ on:
       - '**.md'
   push:
     branches:
+      - develop
       - main
+      - master
     paths:
       - '**.md'
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -3,7 +3,9 @@ on:
   pull_request:
   push:
     branches:
+      - develop
       - main
+      - master
 
 jobs:
   Gosec:

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -4,7 +4,9 @@ on:
   pull_request: {}
   push:
     branches:
+      - develop
       - main
+      - master
     paths:
       - .github/workflows/semgrep.yml
   schedule:
@@ -19,7 +21,8 @@ jobs:
     if: (github.actor != 'dependabot[bot]')
     steps:
       - name: Permission issue fix
-        run: git config --global --add safe.directory /__w/ExocoreNetwork/exocore
+        # semgrep for some reason sets the working directory to exocore/exocore
+        run: git config --global --add safe.directory /__w/exocore/exocore
       - uses: actions/checkout@v4
       - name: Get Diff
         uses: technote-space/get-diff-action@v6.1.2

--- a/.github/workflows/slither.yml
+++ b/.github/workflows/slither.yml
@@ -1,42 +1,43 @@
-name: Slither Analysis
+# # Disabled, since we do not have any contracts in this repo.
+# name: Slither Analysis
 
-on:
-  pull_request:
-  push:
-    branches:
-      - develop
-      - main
-      - master
+# on:
+#   pull_request:
+#   push:
+#     branches:
+#       - develop
+#       - main
+#       - master
 
-jobs:
-  analyze:
-    name: Run Slither
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      security-events: write
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-      - name: Get Diff
-        uses: technote-space/get-diff-action@v6.1.2
-        with:
-          PATTERNS: |
-            **/*.sol
-      - name: Node dependencies Install
-        run: |
-          cd contracts && npm i
-          cp -r node_modules/@openzeppelin .
-      - name: Run Slither Action
-        uses: crytic/slither-action@v0.3.0
-        continue-on-error: true
-        id: slither
-        with:
-          sarif: slither.sarif
-          target: contracts/
-        if: "env.GIT_DIFF"
-      - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v2
-        with:
-          sarif_file: ${{ steps.slither.outputs.sarif }}
-        if: "env.GIT_DIFF"
+# jobs:
+#   analyze:
+#     name: Run Slither
+#     runs-on: ubuntu-latest
+#     permissions:
+#       contents: read
+#       security-events: write
+#     steps:
+#       - name: Checkout repository
+#         uses: actions/checkout@v4
+#       - name: Get Diff
+#         uses: technote-space/get-diff-action@v6.1.2
+#         with:
+#           PATTERNS: |
+#             **/*.sol
+#       - name: Node dependencies Install
+#         run: |
+#           cd contracts && npm i
+#           cp -r node_modules/@openzeppelin .
+#       - name: Run Slither Action
+#         uses: crytic/slither-action@v0.3.0
+#         continue-on-error: true
+#         id: slither
+#         with:
+#           sarif: slither.sarif
+#           target: contracts/
+#         if: "env.GIT_DIFF"
+#       - name: Upload SARIF file
+#         uses: github/codeql-action/upload-sarif@v2
+#         with:
+#           sarif_file: ${{ steps.slither.outputs.sarif }}
+#         if: "env.GIT_DIFF"

--- a/.github/workflows/slither.yml
+++ b/.github/workflows/slither.yml
@@ -4,7 +4,9 @@ on:
   pull_request:
   push:
     branches:
+      - develop
       - main
+      - master
 
 jobs:
   analyze:

--- a/.github/workflows/slither.yml
+++ b/.github/workflows/slither.yml
@@ -1,43 +1,42 @@
-# # Disabled, since we do not have any contracts in this repo.
-# name: Slither Analysis
+name: Slither Analysis
 
-# on:
-#   pull_request:
-#   push:
-#     branches:
-#       - develop
-#       - main
-#       - master
+on:
+  pull_request:
+  push:
+    branches:
+      - develop
+      - main
+      - master
 
-# jobs:
-#   analyze:
-#     name: Run Slither
-#     runs-on: ubuntu-latest
-#     permissions:
-#       contents: read
-#       security-events: write
-#     steps:
-#       - name: Checkout repository
-#         uses: actions/checkout@v4
-#       - name: Get Diff
-#         uses: technote-space/get-diff-action@v6.1.2
-#         with:
-#           PATTERNS: |
-#             **/*.sol
-#       - name: Node dependencies Install
-#         run: |
-#           cd contracts && npm i
-#           cp -r node_modules/@openzeppelin .
-#       - name: Run Slither Action
-#         uses: crytic/slither-action@v0.3.0
-#         continue-on-error: true
-#         id: slither
-#         with:
-#           sarif: slither.sarif
-#           target: contracts/
-#         if: "env.GIT_DIFF"
-#       - name: Upload SARIF file
-#         uses: github/codeql-action/upload-sarif@v2
-#         with:
-#           sarif_file: ${{ steps.slither.outputs.sarif }}
-#         if: "env.GIT_DIFF"
+jobs:
+  analyze:
+    name: Run Slither
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Get Diff
+        uses: technote-space/get-diff-action@v6.1.2
+        with:
+          PATTERNS: |
+            **/*.sol
+      - name: Node dependencies Install
+        run: |
+          cd contracts && npm i
+          cp -r node_modules/@openzeppelin .
+      - name: Run Slither Action
+        uses: crytic/slither-action@v0.3.0
+        continue-on-error: true
+        id: slither
+        with:
+          sarif: slither.sarif
+          target: contracts/
+        if: "env.GIT_DIFF"
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: ${{ steps.slither.outputs.sarif }}
+        if: "env.GIT_DIFF"

--- a/.github/workflows/slither.yml
+++ b/.github/workflows/slither.yml
@@ -10,6 +10,8 @@ on:
 
 jobs:
   analyze:
+    # disabled for now, since we don't have any Solidity files.
+    if: ${{ false }}
     name: Run Slither
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/solidity-test.yml
+++ b/.github/workflows/solidity-test.yml
@@ -2,7 +2,9 @@ name: Solidity Test
 on:
   pull_request:
     branches:
+      - develop
       - main
+      - master
       - release/**
 
 jobs:
@@ -11,7 +13,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: '1.21'
           check-latest: true
       - uses: actions/checkout@v4
       - uses: technote-space/get-diff-action@v6.1.2

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -9,9 +9,9 @@ name: Lint Code Base
 
 on:
   push:
-    branches: ["main"]
+    branches: ["develop", "main", "master"]
   pull_request:
-    branches: ["main"]
+    branches: ["develop", "main", "master"]
 jobs:
   run-lint:
     runs-on: ubuntu-latest
@@ -34,5 +34,5 @@ jobs:
           VALIDATE_OPENAPI: false
           VALIDATE_JSCPD: false
           VALIDATE_GO: false
-          DEFAULT_BRANCH: "main"
+          DEFAULT_BRANCH: "master"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,24 +3,23 @@ on:
   pull_request:
   push:
     branches:
+      - develop
       - main
+      - master
       - release/**
 
-jobs:
-  cleanup-runs:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: rokroskar/workflow-run-cleanup-action@master
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-    if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/main'"
+# Automatically cancel run if another commit to the same ref is detected.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
+jobs:
   test-unit-cover:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: '1.21'
           check-latest: true
       - uses: actions/checkout@v4
       - uses: technote-space/get-diff-action@v6.1.2


### PR DESCRIPTION
This PR activates all of the Github workflows in `.github/workflows` for branches `develop`, `main` and `master` with Go version 1.21. In addition, it disables the Solidity workflow (since we don't have any Solidity file, which is not a precompile, within the repository). Lastly, it fixes a small YAML indentation linting issue in the `labeler.yml` workflow.