### PR TITLE
chore(ci): fix labeler and consensuswarn

### DIFF
--- a/.github/workflows/consensuswarn.yml
+++ b/.github/workflows/consensuswarn.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       # This is used for warning when a PR touches any of the roots, or any function or method directly or indirectly called by a root
       - uses: actions/checkout@v4
+        with:
+          path: 'ExocoreNetwork/exocore'
       - uses: orijtech/consensuswarn@main
         with:
           # example.com/pkg/path.Type.Method

--- a/.github/workflows/consensuswarn.yml
+++ b/.github/workflows/consensuswarn.yml
@@ -20,4 +20,4 @@ jobs:
       - uses: orijtech/consensuswarn@main
         with:
           # example.com/pkg/path.Type.Method
-          roots: 'github.com/ExocoreNetwork/exocore/app.ExocoreApp.BaseApp.DeliverTx,github.com/ExocoreNetwork/exocore/app.ExocoreApp.BaseApp.BeginBlocker,github.com/ExocoreNetwork/exocore/app.ExocoreApp.BaseApp.EndBlocker'
+          roots: 'github.com/ExocoreNetwork/exocore/app.ExocoreApp.DeliverTx,github.com/ExocoreNetwork/exocore/app.ExocoreApp.BeginBlocker,github.com/ExocoreNetwork/exocore/app.ExocoreApp.EndBlocker'

--- a/.github/workflows/consensuswarn.yml
+++ b/.github/workflows/consensuswarn.yml
@@ -15,8 +15,6 @@ jobs:
     steps:
       # This is used for warning when a PR touches any of the roots, or any function or method directly or indirectly called by a root
       - uses: actions/checkout@v4
-        with:
-          path: 'ExocoreNetwork/exocore'
       - uses: orijtech/consensuswarn@main
         with:
           # example.com/pkg/path.Type.Method

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,11 +1,7 @@
 name: "Pull Request Labeler"
+
 on:
   pull_request_target:
-  push:
-    branches:
-      - develop
-      - main
-      - master
 
 jobs:
   triage:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,6 +1,6 @@
 name: "Pull Request Labeler"
 on:
-  pull_request:
+  pull_request_target:
   push:
     branches:
       - develop
@@ -10,6 +10,9 @@ on:
 jobs:
   triage:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/labeler@v4
         with:


### PR DESCRIPTION
This PR fixes the failing `consensuswarn` and `labeler` workflows.