### PR TITLE
fix(ci): run build on branches

### DIFF
--- a/.github/workflows/ante-benchmark.yml
+++ b/.github/workflows/ante-benchmark.yml
@@ -9,14 +9,14 @@ on:
       - develop
       - main
       - master
-    paths: 
+    paths:
       - 'app/ante/**'
   pull_request:
     branches:
       - develop
       - main
       - master
-    paths: 
+    paths:
       - 'app/ante/**'
 
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,7 @@
 name: Build
 on:
   pull_request:
+  push:
     branches:
       - develop
       - main

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -1,4 +1,5 @@
 name: "Dependency Review"
+# only run on pull requests and not any branch.
 on: pull_request
 
 permissions:

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -10,6 +10,7 @@ on:
       - main
       - master
     paths:
+      # existing issues to be ignored unless this file changes
       - .github/workflows/semgrep.yml
   schedule:
     - cron: '0 0 * * 0'

--- a/.github/workflows/solidity-test.yml
+++ b/.github/workflows/solidity-test.yml
@@ -1,6 +1,7 @@
 name: Solidity Test
 on:
   pull_request:
+  push:
     branches:
       - develop
       - main


### PR DESCRIPTION
The `build.yml` CI was not previously set up to run after a push on the `develop` branch. This PR enables that.