### PR TITLE
fix: change keyring, feat: consistent local key

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -482,7 +482,7 @@ localnet-build:
 # Generate multi node configuration files and initialize configurations
 # TODO: exocore testnet chainid is still under consideration and need to be finalized later
 localnet-init: localnet-stop
-	exocored testnet init-files --chain-id exocoretestnet_233-1 --v 4 -o  $(CURDIR)/build/.testnets --starting-ip-address 192.168.0.2 --keyring-backend=os  && \
+	exocored testnet init-files --chain-id exocoretestnet_233-1 --v 4 -o  $(CURDIR)/build/.testnets --starting-ip-address 192.168.0.2 --keyring-backend=test && \
 	./networks/init-node.sh
 
 # Start a 4-node testnet locally


### PR DESCRIPTION
feat(test): use consistent addresses in localnet
    
`local_node.sh` is used to run a single validator localnet for testing.
The consensus public key of this validator needs to be consistent for
comparison across multiple runs of the script. This change enables that.
    
Secondly, it also adds a consistent locally funded account with private
key D196DCA836F8AC2FFF45B3C9F0113825CCBB33FA1B39737B948503B263ED75AE to
allow easier deployment across multiple re-runs of the script.



fix(build): use `test` backend for localnet
    
The `os` backend is not recommended for use in headless environments,
and hence we replace it with the `test` backend. Note that it stores the
keys in plaintext and is therefore simply the `file` backend without the
encryption.
    
For deployments of public networks in headless environments, Cosmos
recommends using `file` or `pass` backends.
