### PR TITLE
fix(assets): require non-zero address length

### DIFF
--- a/local_node.sh
+++ b/local_node.sh
@@ -87,6 +87,7 @@ if [[ $overwrite == "y" || $overwrite == "Y" ]]; then
 	# x/assets
 	jq '.app_state["assets"]["client_chains"][0]["name"]="Example EVM chain"' "$GENESIS" >"$TMP_GENESIS" && mv "$TMP_GENESIS" "$GENESIS"
 	jq '.app_state["assets"]["client_chains"][0]["layer_zero_chain_id"]="101"' "$GENESIS" >"$TMP_GENESIS" && mv "$TMP_GENESIS" "$GENESIS"
+	jq '.app_state["assets"]["client_chains"][0]["address_length"]="20"' "$GENESIS" >"$TMP_GENESIS" && mv "$TMP_GENESIS" "$GENESIS"
 	jq '.app_state["assets"]["tokens"][0]["asset_basic_info"]["address"]="0xdAC17F958D2ee523a2206206994597C13D831ec7"' "$GENESIS" >"$TMP_GENESIS" && mv "$TMP_GENESIS" "$GENESIS"
 	jq '.app_state["assets"]["tokens"][0]["asset_basic_info"]["layer_zero_chain_id"]="101"' "$GENESIS" >"$TMP_GENESIS" && mv "$TMP_GENESIS" "$GENESIS"
 	jq '.app_state["assets"]["tokens"][0]["asset_basic_info"]["total_supply"]="40022689732746729"' "$GENESIS" >"$TMP_GENESIS" && mv "$TMP_GENESIS" "$GENESIS"

--- a/x/assets/types/genesis.go
+++ b/x/assets/types/genesis.go
@@ -42,6 +42,7 @@ func (gs GenesisState) Validate() error {
 				i,
 			)
 		}
+		// this is our primary method of cross-chain communication.
 		if info.LayerZeroChainID == 0 {
 			return errorsmod.Wrapf(
 				ErrInvalidGenesisData,
@@ -49,6 +50,15 @@ func (gs GenesisState) Validate() error {
 				info.Name,
 			)
 		}
+		// the address length is used to convert from bytes32 to address.
+		if info.AddressLength == 0 {
+			return errorsmod.Wrapf(
+				ErrInvalidGenesisData,
+				"nil AddressLength for chain %s",
+				info.Name,
+			)
+		}
+		// check for no duplicated chain, indexed by LayerZeroChainID.
 		if _, ok := lzIDs[info.LayerZeroChainID]; ok {
 			return errorsmod.Wrapf(
 				ErrInvalidGenesisData,

--- a/x/assets/types/genesis_test.go
+++ b/x/assets/types/genesis_test.go
@@ -109,6 +109,38 @@ func (suite *GenesisTestSuite) TestValidateGenesis() {
 			expPass: false,
 		},
 		{
+			name: "invalid genesis due to zero layer zero chain id",
+			genState: &types.GenesisState{
+				Params: types.DefaultParams(),
+				ClientChains: []types.ClientChainInfo{
+					ethClientChain,
+				},
+			},
+			malleate: func(gs *types.GenesisState) {
+				gs.ClientChains[0].LayerZeroChainID = 0
+			},
+			unmalleate: func(gs *types.GenesisState) {
+				gs.ClientChains[0].LayerZeroChainID = 101
+			},
+			expPass: false,
+		},
+		{
+			name: "invalid genesis due to zero address length",
+			genState: &types.GenesisState{
+				Params: types.DefaultParams(),
+				ClientChains: []types.ClientChainInfo{
+					ethClientChain,
+				},
+			},
+			malleate: func(gs *types.GenesisState) {
+				gs.ClientChains[0].AddressLength = 0
+			},
+			unmalleate: func(gs *types.GenesisState) {
+				gs.ClientChains[0].AddressLength = 20
+			},
+			expPass: false,
+		},
+		{
 			name: "invalid genesis due to missing client chain",
 			genState: &types.GenesisState{
 				Params: types.DefaultParams(),


### PR DESCRIPTION
This PR adds a check in the `ValidateGenesis` function of `x/assets` to ensure that an address length is provided at launch. It adds an associated test, and sets the address length in `local_node.sh`.