### PR TITLE
fix(app): reorder the EndBlockers

### DIFF
--- a/.github/workflows/ante-benchmark.yml
+++ b/.github/workflows/ante-benchmark.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@v4
         with:
-          go-version: '1.21.9'
+          go-version: '1.21.11'
           check-latest: true
 
       - name: Run benchmark tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.21.9'
+          go-version: '1.21.11'
           check-latest: true
       - uses: technote-space/get-diff-action@v6.1.2
         id: git_diff

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.21.9'
+          go-version: '1.21.11'
           check-latest: true
       - name: "Checkout Repository"
         uses: actions/checkout@v4

--- a/.github/workflows/docker-localnet.yml
+++ b/.github/workflows/docker-localnet.yml
@@ -2,11 +2,11 @@ name: Docker build for localnet
 on:
   pull_request:
     paths:
-      - local/exocore/Dockerfile
+      - networks/local/exocore/Dockerfile
       - networks/Makefile
   push:
     paths:
-      - local/exocore/Dockerfile
+      - networks/local/exocore/Dockerfile
       - networks/Makefile
     branches:
       - develop

--- a/.github/workflows/docker-localnet.yml
+++ b/.github/workflows/docker-localnet.yml
@@ -9,7 +9,7 @@ on:
       - release/**
 
 permissions:
-    contents: read
+  contents: read
 
 jobs:
   build:

--- a/.github/workflows/docker-localnet.yml
+++ b/.github/workflows/docker-localnet.yml
@@ -1,0 +1,23 @@
+name: Docker Build `./local/exocore/Dockerfile`
+on:
+  pull_request:
+  push:
+    branches:
+      - develop
+      - main
+      - master
+      - release/**
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Build Docker image
+      run: make -C ./networks

--- a/.github/workflows/docker-localnet.yml
+++ b/.github/workflows/docker-localnet.yml
@@ -8,6 +8,9 @@ on:
       - master
       - release/**
 
+permissions:
+    contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-localnet.yml
+++ b/.github/workflows/docker-localnet.yml
@@ -1,7 +1,13 @@
 name: Docker Build `./local/exocore/Dockerfile`
 on:
   pull_request:
+    paths:
+      - local/exocore/Dockerfile
+      - networks/Makefile
   push:
+    paths:
+      - local/exocore/Dockerfile
+      - networks/Makefile
     branches:
       - develop
       - main

--- a/.github/workflows/docker-localnet.yml
+++ b/.github/workflows/docker-localnet.yml
@@ -1,4 +1,4 @@
-name: Docker Build `./local/exocore/Dockerfile`
+name: Docker build for localnet
 on:
   pull_request:
     paths:

--- a/.github/workflows/docker-localnet.yml
+++ b/.github/workflows/docker-localnet.yml
@@ -22,11 +22,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-    - name: Build Docker image
-      run: make -C ./networks
+      - name: Build Docker image
+        run: make -C ./networks

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,11 +20,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-    - name: Build Docker image
-      run: docker build .
+      - name: Build Docker image
+        run: docker build .

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,7 +1,11 @@
 name: Docker Build `./Dockerfile`
 on:
   pull_request:
+    paths:
+      - Dockerfile
   push:
+    paths:
+      - Dockerfile
     branches:
       - develop
       - main

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,7 +9,7 @@ on:
       - release/**
 
 permissions:
-    contents: read
+  contents: read
 
 jobs:
   build:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,4 +1,4 @@
-name: Docker Build `./Dockerfile`
+name: Docker build in root directory
 on:
   pull_request:
     paths:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,6 +8,9 @@ on:
       - master
       - release/**
 
+permissions:
+    contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,23 @@
+name: Docker Build `./Dockerfile`
+on:
+  pull_request:
+  push:
+    branches:
+      - develop
+      - main
+      - master
+      - release/**
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Build Docker image
+      run: docker build .

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.21.9'
+          go-version: '1.21.11'
           check-latest: true
       - name: release dry run
         run: make release-dry-run

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
       # Required: setup-go, for all versions v3.0.0+ of golangci-lint
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.21.9'
+          go-version: '1.21.11'
           # Use pinned versions, not git versions
           check-latest: false
           # Match `golangci-lint-action` recommendation

--- a/.github/workflows/proto-comment.yml
+++ b/.github/workflows/proto-comment.yml
@@ -18,7 +18,8 @@ jobs:
   download-artifact-and-comment:
     runs-on: ubuntu-latest
     if: >
-      github.event.workflow_run.conclusion == 'success'
+      github.event.workflow_run.conclusion == 'success' &&
+      ${{ false }}
     steps:
       - name: 'Download artifact'
         uses: actions/github-script@v7.0.1

--- a/.github/workflows/proto-comment.yml
+++ b/.github/workflows/proto-comment.yml
@@ -17,9 +17,7 @@ on:
 jobs:
   download-artifact-and-comment:
     runs-on: ubuntu-latest
-    if: >
-      github.event.workflow_run.conclusion == 'success' &&
-      ${{ false }}
+    if: ${{ false }}
     steps:
       - name: 'Download artifact'
         uses: actions/github-script@v7.0.1

--- a/.github/workflows/test-comment.yml
+++ b/.github/workflows/test-comment.yml
@@ -18,10 +18,7 @@ on:
 jobs:
   download-artifact-and-comment:
     runs-on: ubuntu-latest
-    if: >
-      github.event.workflow_run.event == 'pull_request' &&
-      github.event.workflow_run.conclusion == 'success' &&
-      ${{ false }}
+    if: ${{ false }}
     steps:
       - name: Download artifact
         uses: actions/github-script@v7.0.1

--- a/.github/workflows/test-comment.yml
+++ b/.github/workflows/test-comment.yml
@@ -20,7 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     if: >
       github.event.workflow_run.event == 'pull_request' &&
-      github.event.workflow_run.conclusion == 'success'
+      github.event.workflow_run.conclusion == 'success' &&
+      ${{ false }}
     steps:
       - name: Download artifact
         uses: actions/github-script@v7.0.1

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,7 @@ run:
   tests: false
   timeout: 5m
   concurrency: 4
-  go: "1.21.9"
+  go: "1.21.11"
 
 linters:
   enable:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 # This is the published docker image for exocore.
 
-FROM golang:1.21.11-alpine3.18 AS build-env
+FROM golang:1.21.11-alpine3.19 AS build-env
 
 WORKDIR /go/src/github.com/ExocoreNetwork/exocore
 
 COPY go.mod go.sum ./
 
-RUN apk add --no-cache ca-certificates=20230506-r0 build-base=0.5-r3 git=2.40.1-r0 linux-headers=6.3-r0
+RUN apk add --no-cache ca-certificates=20240226-r0 build-base=0.5-r3 git=2.43.4-r0 linux-headers=6.5-r0
 
 RUN --mount=type=bind,target=. --mount=type=secret,id=GITHUB_TOKEN \
     git config --global url."https://$(cat /run/secrets/GITHUB_TOKEN)@github.com/".insteadOf "https://github.com/"; \
@@ -16,14 +16,14 @@ COPY . .
 
 RUN make build && go install github.com/MinseokOh/toml-cli@latest
 
-FROM alpine:3.18
+FROM alpine:3.19
 
 WORKDIR /root
 
 COPY --from=build-env /go/src/github.com/ExocoreNetwork/exocore/build/exocored /usr/bin/exocored
 COPY --from=build-env /go/bin/toml-cli /usr/bin/toml-cli
 
-RUN apk add --no-cache ca-certificates=20230506-r0 libstdc++=12.2.1_git20220924-r10 jq=1.6-r4 curl=8.5.0-r0 bash=5.2.15-r5 vim=9.0.2073-r0 lz4=1.9.4-r4 rclone=1.62.2-r6 \
+RUN apk add --no-cache ca-certificates=20240226-r0 libstdc++=13.2.1_git20231014-r0 jq=1.7.1-r0 curl=8.5.0-r0 bash=5.2.21-r0 vim=9.0.2127-r0 lz4=1.9.4-r5 rclone=1.65.0-r3 \
     && addgroup -g 1000 exocore \
     && adduser -S -h /home/exocore -D exocore -u 1000 -G exocore
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # This is the published docker image for exocore.
 
-FROM golang:1.21.9-alpine3.18 AS build-env
+FROM golang:1.21.11-alpine3.18 AS build-env
 
 WORKDIR /go/src/github.com/ExocoreNetwork/exocore
 

--- a/Makefile
+++ b/Makefile
@@ -525,7 +525,7 @@ localnet-show-logstream:
 ###############################################################################
 
 PACKAGE_NAME:=github.com/ExocoreNetwork/exocore
-GOLANG_CROSS_VERSION  = v1.21.9
+GOLANG_CROSS_VERSION  = v1.21.11
 GOPATH ?= '$(HOME)/go'
 release-dry-run:
 	docker run \

--- a/app/app.go
+++ b/app/app.go
@@ -939,12 +939,12 @@ func NewExocoreApp(
 
 	app.mm.SetOrderEndBlockers(
 		capabilitytypes.ModuleName,
-		crisistypes.ModuleName, // easy quit
-		stakingtypes.ModuleName,
-		operatorTypes.ModuleName,   // after staking keeper
-		delegationTypes.ModuleName, // after operator keeper
+		crisistypes.ModuleName,     // easy quit
+		operatorTypes.ModuleName,   // first, so that USD value is recorded
+		stakingtypes.ModuleName,    // uses the USD value recorded in operator to calculate vote power
+		delegationTypes.ModuleName, // process the undelegations matured by dogfood
 		govtypes.ModuleName,        // after staking keeper to ensure new vote powers
-		oracleTypes.ModuleName,     // after staking keeper to ensure new vote powers
+		oracleTypes.ModuleName,     // prepares for next round with new vote powers from staking keeper
 		evmtypes.ModuleName,        // can be anywhere
 		feegrant.ModuleName,        // can be anywhere
 		// no-op modules

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ExocoreNetwork/exocore
 
-go 1.21.9
+go 1.21.11
 
 require (
 	cosmossdk.io/errors v1.0.1

--- a/networks/local/exocore/Dockerfile
+++ b/networks/local/exocore/Dockerfile
@@ -1,5 +1,5 @@
-FROM golang:1.21.11-alpine3.18 AS build
-RUN apk add --no-cache build-base=0.5-r3 linux-headers=6.3-r0 git=2.40.1-r0
+FROM golang:1.21.11-alpine3.19 AS build
+RUN apk add --no-cache build-base=0.5-r3 git=2.43.4-r0 linux-headers=6.5-r0
 # Set working directory for the build
 WORKDIR /go/work
 # Add source files
@@ -9,8 +9,8 @@ COPY . ./
 RUN LEDGER_ENABLED=false make build
 
 #####################################
-FROM alpine:3.18 AS run
-RUN apk add --no-cache libstdc++=12.2.1_git20220924-r10 bash=5.2.15-r5 curl=8.5.0-r0 jq=1.6-r4 \
+FROM alpine:3.19 AS run
+RUN apk add --no-cache libstdc++=13.2.1_git20231014-r0 bash=5.2.21-r0 curl=8.5.0-r0 jq=1.7.1-r0 \
     && addgroup -g 1000 exocore \
     && adduser -S -h /home/exocore -D exocore -u 1000 -G exocore
 EXPOSE 26656 26657 1317 9090 8545 8546

--- a/networks/local/exocore/Dockerfile
+++ b/networks/local/exocore/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.9-alpine3.18 AS build
+FROM golang:1.21.11-alpine3.18 AS build
 RUN apk add --no-cache build-base=0.5-r3 linux-headers=6.3-r0 git=2.40.1-r0
 # Set working directory for the build
 WORKDIR /go/work


### PR DESCRIPTION
commit e5a6ddc33b8f9d9eee3268e3436cd023096dfdf2
Author: MaxMustermann2 <82761650+MaxMustermann2@users.noreply.github.com>
Date:   Wed Jun 12 09:35:49 2024 +0000

    fix(app): reorder the EndBlockers
    
    The `EndBlockers` do the following jobs:
    - `x/operator` saves the USD value for delegations, indexed by operator.
    - `x/dogfood` uses the USD value obtained from `x/operator` to calculate
      the new voting power and forwards the new validator set to Tendermint.
      It also decreases the hold count on pending undelegations maturing at
      that epoch, from the perspective of the dogfood-AVS.
    - `x/delegation` releases any matured undelegations and makes assets
      available for withdrawal.
    - `x/oracle` fetches the new voting power from `x/dogfood` and prepares
      for the next round.
    
    The new order is updated to reflect the above functions. As a
    consequence, delegations made during blocks just before the epoch ends
    will also accurately update the vote power of the validators.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated Go version from `1.21.9` to `1.21.11` in various GitHub Actions workflows, Dockerfiles, and configuration files to ensure compatibility and security.

- **Refactor**
  - Reorganized module initialization order in the application setup to improve logical flow and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->