### PR TITLE
fix(oracle):use ConsAddress as validatorset key

### DIFF
--- a/x/oracle/keeper/aggregator/context.go
+++ b/x/oracle/keeper/aggregator/context.go
@@ -71,6 +71,7 @@ func (agc *AggregatorContext) Copy4CheckTx() *AggregatorContext {
 	return ret
 }
 
+// sanity check for the msgCreatePrice
 func (agc *AggregatorContext) sanityCheck(msg *types.MsgCreatePrice) error {
 	// sanity check
 	// TODO: check nonce [1,3] in anteHandler, related to params, may not able
@@ -78,7 +79,9 @@ func (agc *AggregatorContext) sanityCheck(msg *types.MsgCreatePrice) error {
 	// TODO: check len(price.prices)>0, len(price.prices._range_eachPriceSource.Prices)>0, at least has one source, and for each source has at least one price
 	// TODO: check for each source, at most maxDetId count price (now in filter, ->anteHandler)
 
-	if agc.validatorsPower[msg.Creator] == nil {
+	if accAddress, err := sdk.AccAddressFromBech32(msg.Creator); err != nil {
+		return errors.New("invalid address")
+	} else if _, ok := agc.validatorsPower[sdk.ConsAddress(accAddress).String()]; !ok {
 		return errors.New("signer is not validator")
 	}
 

--- a/x/oracle/keeper/aggregator/worker.go
+++ b/x/oracle/keeper/aggregator/worker.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ExocoreNetwork/exocore/x/oracle/keeper/common"
 	"github.com/ExocoreNetwork/exocore/x/oracle/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 // worker is the actual instance used to calculate final price for each tokenFeeder's round. Which means, every tokenFeeder corresponds to a specified token, and for that tokenFeeder, each round we use a worker instance to calculate the final price
@@ -22,7 +23,8 @@ type worker struct {
 }
 
 func (w *worker) do(msg *types.MsgCreatePrice) []*types.PriceSource {
-	validator := msg.Creator
+	accAddress, _ := sdk.AccAddressFromBech32(msg.Creator)
+	validator := sdk.ConsAddress(accAddress).String()
 	power := w.ctx.validatorsPower[validator]
 	list4Calculator, list4Aggregator := w.f.filtrate(msg)
 	if list4Aggregator != nil {

--- a/x/oracle/keeper/single.go
+++ b/x/oracle/keeper/single.go
@@ -78,7 +78,7 @@ func recacheAggregatorContext(ctx sdk.Context, agc *aggregator.AggregatorContext
 	validatorPowers := make(map[string]*big.Int)
 	validatorSet := k.GetAllExocoreValidators(ctx)
 	for _, v := range validatorSet {
-		validatorPowers[sdk.AccAddress(v.Address).String()] = big.NewInt(v.Power)
+		validatorPowers[sdk.ConsAddress(v.Address).String()] = big.NewInt(v.Power)
 		totalPower = new(big.Int).Add(totalPower, big.NewInt(v.Power))
 	}
 	agc.SetValidatorPowers(validatorPowers)
@@ -156,7 +156,7 @@ func initAggregatorContext(ctx sdk.Context, agc *aggregator.AggregatorContext, k
 	validatorPowers := make(map[string]*big.Int)
 	validatorSet := k.GetAllExocoreValidators(ctx)
 	for _, v := range validatorSet {
-		validatorPowers[sdk.AccAddress(v.Address).String()] = big.NewInt(v.Power)
+		validatorPowers[sdk.ConsAddress(v.Address).String()] = big.NewInt(v.Power)
 		totalPower = new(big.Int).Add(totalPower, big.NewInt(v.Power))
 	}
 

--- a/x/oracle/module.go
+++ b/x/oracle/module.go
@@ -164,8 +164,7 @@ func (am AppModule) EndBlock(ctx sdk.Context, _ abci.RequestEndBlock) []abci.Val
 		validatorList := make(map[string]*big.Int)
 		for _, vu := range validatorUpdates {
 			pubKey, _ := cryptocodec.FromTmProtoPublicKey(vu.PubKey)
-			validator, _ := am.keeper.GetValidatorByConsAddr(ctx, sdk.GetConsAddress(pubKey))
-			validatorList[validator.OperatorAddress] = big.NewInt(vu.Power)
+			validatorList[sdk.AccAddress(pubKey.Address()).String()] = big.NewInt(vu.Power)
 		}
 		// update validator set information in cache
 		cs.AddCache(cache.ItemV(validatorList))

--- a/x/oracle/module.go
+++ b/x/oracle/module.go
@@ -164,7 +164,7 @@ func (am AppModule) EndBlock(ctx sdk.Context, _ abci.RequestEndBlock) []abci.Val
 		validatorList := make(map[string]*big.Int)
 		for _, vu := range validatorUpdates {
 			pubKey, _ := cryptocodec.FromTmProtoPublicKey(vu.PubKey)
-			validatorList[sdk.AccAddress(pubKey.Address()).String()] = big.NewInt(vu.Power)
+			validatorList[sdk.ConsAddress(pubKey.Address()).String()] = big.NewInt(vu.Power)
 		}
 		// update validator set information in cache
 		cs.AddCache(cache.ItemV(validatorList))


### PR DESCRIPTION
## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->
<strike>_When send create-pice message to oracle module, the message need to be signed by validator's consensusKey, the address is convert to `accAddress` as a signer. Use `accAddress` in validatorSet key to keep consistent._</strike>
When send create-pice message to oracle module, the message need to be signed by validator's consensusKey, the address is convert to `ConsAddress` as a signer. Use `accAddress` in validatorSet key to keep consistent.
## Changes
Notable changes:
- use `ConsAddress` instead of `AccAddress` in validatorList since it's derived from consensusKey
- convert message's singer string from `AccAddress` to `ConsAddress` for comparison

----

Closes #XXX

<!--
< < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

PR review checkboxes:

I have...

- [ ] added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] included the correct
      [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json)
      in the PR title
- [ ] targeted the correct branch
      (see [PR Targeting](https://github.com/ExocoreNetwork/exocore/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link in the PR description to the relevant issue or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all required CI checks have passed

Code maintenance:

I have...

- [ ] written unit and integration [tests](https://github.com/ExocoreNetwork/exocore/blob/main/CONTRIBUTING.md#testing)
- [ ] added relevant [`godoc`](https://go.dev/blog/godoc) and [code comments](https://blog.jbowen.dev/2019/09/the-magic-of-go-comments/).
- [ ] updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)

______

### Reviewers Checklist

**All** items are required.
Please add a note if the item is not applicable
and please add your handle next to the items reviewed
if you only reviewed selected items.

I have...

- [ ] confirmed the correct
      [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json)
      in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] confirmed that this PR does not change production code

-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added address validation in price creation messages.

- **Bug Fixes**
  - Corrected the logic for updating validator power using account addresses instead of operator addresses.
  
- **Refactor**
  - Updated internal address handling to use consensus addresses for better compatibility with Cosmos SDK.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->