### PR TITLE
fix(ci): specify go version in consensuswarn

### DIFF
--- a/.github/workflows/consensuswarn.yml
+++ b/.github/workflows/consensuswarn.yml
@@ -17,6 +17,8 @@ jobs:
       contents: read
       pull-requests: write  # For reading the PR and posting comment
     runs-on: ubuntu-latest
+    env:
+      GOTOOLCHAIN: "go1.21.11"
     steps:
       # This is used for warning when a PR touches any of the roots, or any function or method directly or indirectly called by a root
       - uses: actions/checkout@v4


### PR DESCRIPTION
We have upgraded our go version to fix a vulnerability. However, the minor version within the `consensuswarn` CI differs and it complains. This PR fixes that problem by specifying the version.

Note that the workflow will still fail for this PR, since the workflows triggered by `pull_request_target` apply on the base branch and not the PR branch. After this PR is merged, the workflow will pass on other / future PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated internal workflow configuration to support Go 1.21.11. This ensures that the build and deployment processes use the latest Go toolchain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->