### PR TITLE
fix(assets,delegation): remove deprecated x/params, add validation

### DIFF
--- a/x/assets/types/params.go
+++ b/x/assets/types/params.go
@@ -3,12 +3,8 @@ package types
 import (
 	"fmt"
 
-	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
-
 	"github.com/ethereum/go-ethereum/common"
 )
-
-var _ paramtypes.ParamSet = (*Params)(nil)
 
 const (
 	// DefaultExocoreLzAppAddress is the default address of ExocoreGateway.sol.
@@ -20,17 +16,6 @@ const (
 	// event. TODO: Set this to a sane default?
 	DefaultExocoreLzAppEventTopic = "0x000000000000000000000000000000000000000000000000000000000000000"
 )
-
-// Reflection based keys for params subspace.
-var (
-	KeyExocoreLzAppAddress    = []byte("ExocoreLzAppAddress")
-	KeyExocoreLzAppEventTopic = []byte("ExocoreLzAppEventTopic")
-)
-
-// ParamKeyTable returns a key table with the necessary registered params.
-func ParamKeyTable() paramtypes.KeyTable {
-	return paramtypes.NewKeyTable().RegisterParamSet(&Params{})
-}
 
 // NewParams creates a new Params instance.
 func NewParams(
@@ -49,22 +34,6 @@ func DefaultParams() Params {
 		DefaultExocoreLzAppAddress,
 		DefaultExocoreLzAppEventTopic,
 	)
-}
-
-// ParamSetPairs implements params.ParamSet
-func (p *Params) ParamSetPairs() paramtypes.ParamSetPairs {
-	return paramtypes.ParamSetPairs{
-		paramtypes.NewParamSetPair(
-			KeyExocoreLzAppAddress,
-			&p.ExocoreLzAppAddress,
-			ValidateHexAddress,
-		),
-		paramtypes.NewParamSetPair(
-			KeyExocoreLzAppEventTopic,
-			&p.ExocoreLzAppEventTopic,
-			ValidateHexHash,
-		),
-	}
 }
 
 // Validate validates the set of params.

--- a/x/delegation/types/errors.go
+++ b/x/delegation/types/errors.go
@@ -83,4 +83,9 @@ var (
 	ErrInsufficientAssetAmount = errorsmod.Register(
 		ModuleName, 16,
 		"insufficient asset amount")
+
+	ErrInvalidHash = errorsmod.Register(
+		ModuleName, 17,
+		"invalid hash",
+	)
 )

--- a/x/delegation/types/keys.go
+++ b/x/delegation/types/keys.go
@@ -105,12 +105,18 @@ func ParseUndelegationRecordKey(key []byte) (field *UndelegationKeyFields, err e
 	if err != nil {
 		return nil, err
 	}
+	hash := stringList[3]
+	// when a key is originally made, it is created with hash.Hex(), which
+	// we reverse by using common.HexToHash. to that end, this validation
+	// is accurate.
+	if len(common.HexToHash(hash)) != common.HashLength {
+		return nil, ErrInvalidHash
+	}
 	return &UndelegationKeyFields{
 		OperatorAddr: operatorAccAddr.String(),
 		BlockHeight:  height,
 		LzNonce:      lzNonce,
-		// TODO: validate the TxHash?
-		TxHash: stringList[3],
+		TxHash:       hash,
 	}, nil
 }
 


### PR DESCRIPTION
- Remove the interface of `ParamSet` implemented by `Params` in the `x/assets` module, since it is deprecated.
- Add validation of the transaction hash being supplied to `ParseUndelegationRecordKey` in `x/delegation`