### PR TITLE
fix(ci): upgrade deprecated goreleaser

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -1,19 +1,26 @@
 name: goreleaser
 
 permissions:
-  # github releases
   contents: write
 
 on:
   push:
     tags:
       - "v*.*.*"
+  # Validate on develop, main, and master branches that the releaser
+  # is working as expected.
+  pull_request:
+    branches:
+      - develop
+      - main
+      - master
+
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
-    environment: release
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v4
         with:
           submodules: true
       - name: Set up Go
@@ -21,12 +28,11 @@ jobs:
         with:
           go-version: '1.21.11'
           check-latest: true
-      - name: release dry run
+      - name: Release dry run
         run: make release-dry-run
-      - name: setup release environment
+      - name: Release publish
+        # Do not publish the release for pull requests.
+        if: github.event_name != 'pull_request'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |-
-          echo 'GITHUB_TOKEN=${{secrets.GITHUB_TOKEN}}' > .release-env
-      - name: release publish
         run: make release

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -8,6 +8,9 @@ on:
   push:
     tags:
       - "v*.*.*"
+env:
+  CGO_CFLAGS: "-O -D__BLST_PORTABLE__"
+  CGO_CFLAGS_ALLOW: "-O -D__BLST_PORTABLE__"
 jobs:
   goreleaser:
     runs-on: ubuntu-latest

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,5 @@
+version: 2
+
 before:
   hooks:
     - go mod download

--- a/Makefile
+++ b/Makefile
@@ -525,7 +525,9 @@ localnet-show-logstream:
 ###############################################################################
 
 PACKAGE_NAME:=github.com/ExocoreNetwork/exocore
-GOLANG_CROSS_VERSION  = v1.21.11
+# There is no `goreleaser-cross` package for 1.21.11, so we use the next
+# available version of v1.22 with goreleaser version 2.0.0
+GOLANG_CROSS_VERSION  = v1.22-v2.0.0
 GOPATH ?= '$(HOME)/go'
 release-dry-run:
 	docker run \
@@ -537,7 +539,7 @@ release-dry-run:
 		-v ${GOPATH}/pkg:/go/pkg \
 		-w /go/src/$(PACKAGE_NAME) \
 		ghcr.io/goreleaser/goreleaser-cross:${GOLANG_CROSS_VERSION} \
-		--clean --skip-validate --skip-publish --snapshot
+		--clean --skip validate,publish --snapshot
 
 release:
 	@if [ ! -f ".release-env" ]; then \


### PR DESCRIPTION
- Set version in `.goreleaser.yml`
- Correct the `goreleaser-cross` version to use the latest available and compatible version
- Update workflow to test release builds on pull requests, but not publish them

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated GitHub Actions workflow to validate branches (`develop`, `main`, `master`) and skip release publishing for pull requests.
  - Introduced a new `version` field in the `.goreleaser.yml` configuration.
  - Updated Makefile `GOLANG_CROSS_VERSION` to `v1.22-v2.0.0` and modified the `release-dry-run` target command for better compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->