### PR TITLE
chore(precompile): Add a precompile test using the local node to facilitate daily testing

### DIFF
--- a/precompiles/assets/assets_binding.go
+++ b/precompiles/assets/assets_binding.go
@@ -1,0 +1,333 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package assets
+
+import (
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+)
+
+// AssetsABI is the input ABI used to generate the binding from.
+const AssetsABI = "[{\"type\":\"function\",\"name\":\"depositTo\",\"inputs\":[{\"name\":\"clientChainID\",\"type\":\"uint32\",\"internalType\":\"uint32\"},{\"name\":\"assetsAddress\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"stakerAddress\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"opAmount\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"success\",\"type\":\"bool\",\"internalType\":\"bool\"},{\"name\":\"latestAssetState\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"getClientChains\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"},{\"name\":\"\",\"type\":\"uint32[]\",\"internalType\":\"uint32[]\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"isRegisteredClientChain\",\"inputs\":[{\"name\":\"clientChainID\",\"type\":\"uint32\",\"internalType\":\"uint32\"}],\"outputs\":[{\"name\":\"success\",\"type\":\"bool\",\"internalType\":\"bool\"},{\"name\":\"isRegistered\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"registerOrUpdateClientChain\",\"inputs\":[{\"name\":\"clientChainID\",\"type\":\"uint32\",\"internalType\":\"uint32\"},{\"name\":\"addressLength\",\"type\":\"uint8\",\"internalType\":\"uint8\"},{\"name\":\"name\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"metaInfo\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"signatureType\",\"type\":\"string\",\"internalType\":\"string\"}],\"outputs\":[{\"name\":\"success\",\"type\":\"bool\",\"internalType\":\"bool\"},{\"name\":\"updated\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"registerOrUpdateTokens\",\"inputs\":[{\"name\":\"clientChainID\",\"type\":\"uint32\",\"internalType\":\"uint32\"},{\"name\":\"token\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"decimals\",\"type\":\"uint8\",\"internalType\":\"uint8\"},{\"name\":\"tvlLimit\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"name\",\"type\":\"string\",\"internalType\":\"string\"},{\"name\":\"metaData\",\"type\":\"string\",\"internalType\":\"string\"}],\"outputs\":[{\"name\":\"success\",\"type\":\"bool\",\"internalType\":\"bool\"},{\"name\":\"updated\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"withdrawPrincipal\",\"inputs\":[{\"name\":\"clientChainID\",\"type\":\"uint32\",\"internalType\":\"uint32\"},{\"name\":\"assetsAddress\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"withdrawAddress\",\"type\":\"bytes\",\"internalType\":\"bytes\"},{\"name\":\"opAmount\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"success\",\"type\":\"bool\",\"internalType\":\"bool\"},{\"name\":\"latestAssetState\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"nonpayable\"}]"
+
+// Assets is an auto generated Go binding around an Ethereum contract.
+type Assets struct {
+	AssetsCaller     // Read-only binding to the contract
+	AssetsTransactor // Write-only binding to the contract
+	AssetsFilterer   // Log filterer for contract events
+}
+
+// AssetsCaller is an auto generated read-only Go binding around an Ethereum contract.
+type AssetsCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// AssetsTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type AssetsTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// AssetsFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type AssetsFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// AssetsSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type AssetsSession struct {
+	Contract     *Assets           // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// AssetsCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type AssetsCallerSession struct {
+	Contract *AssetsCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts // Call options to use throughout this session
+}
+
+// AssetsTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type AssetsTransactorSession struct {
+	Contract     *AssetsTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// AssetsRaw is an auto generated low-level Go binding around an Ethereum contract.
+type AssetsRaw struct {
+	Contract *Assets // Generic contract binding to access the raw methods on
+}
+
+// AssetsCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type AssetsCallerRaw struct {
+	Contract *AssetsCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// AssetsTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type AssetsTransactorRaw struct {
+	Contract *AssetsTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewAssets creates a new instance of Assets, bound to a specific deployed contract.
+func NewAssets(address common.Address, backend bind.ContractBackend) (*Assets, error) {
+	contract, err := bindAssets(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &Assets{AssetsCaller: AssetsCaller{contract: contract}, AssetsTransactor: AssetsTransactor{contract: contract}, AssetsFilterer: AssetsFilterer{contract: contract}}, nil
+}
+
+// NewAssetsCaller creates a new read-only instance of Assets, bound to a specific deployed contract.
+func NewAssetsCaller(address common.Address, caller bind.ContractCaller) (*AssetsCaller, error) {
+	contract, err := bindAssets(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &AssetsCaller{contract: contract}, nil
+}
+
+// NewAssetsTransactor creates a new write-only instance of Assets, bound to a specific deployed contract.
+func NewAssetsTransactor(address common.Address, transactor bind.ContractTransactor) (*AssetsTransactor, error) {
+	contract, err := bindAssets(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &AssetsTransactor{contract: contract}, nil
+}
+
+// NewAssetsFilterer creates a new log filterer instance of Assets, bound to a specific deployed contract.
+func NewAssetsFilterer(address common.Address, filterer bind.ContractFilterer) (*AssetsFilterer, error) {
+	contract, err := bindAssets(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &AssetsFilterer{contract: contract}, nil
+}
+
+// bindAssets binds a generic wrapper to an already deployed contract.
+func bindAssets(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := abi.JSON(strings.NewReader(AssetsABI))
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_Assets *AssetsRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _Assets.Contract.AssetsCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_Assets *AssetsRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Assets.Contract.AssetsTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_Assets *AssetsRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _Assets.Contract.AssetsTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_Assets *AssetsCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _Assets.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_Assets *AssetsTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Assets.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_Assets *AssetsTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _Assets.Contract.contract.Transact(opts, method, params...)
+}
+
+// GetClientChains is a free data retrieval call binding the contract method 0x41a3745b.
+//
+// Solidity: function getClientChains() view returns(bool, uint32[])
+func (_Assets *AssetsCaller) GetClientChains(opts *bind.CallOpts) (bool, []uint32, error) {
+	var out []interface{}
+	err := _Assets.contract.Call(opts, &out, "getClientChains")
+
+	if err != nil {
+		return *new(bool), *new([]uint32), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+	out1 := *abi.ConvertType(out[1], new([]uint32)).(*[]uint32)
+
+	return out0, out1, err
+
+}
+
+// GetClientChains is a free data retrieval call binding the contract method 0x41a3745b.
+//
+// Solidity: function getClientChains() view returns(bool, uint32[])
+func (_Assets *AssetsSession) GetClientChains() (bool, []uint32, error) {
+	return _Assets.Contract.GetClientChains(&_Assets.CallOpts)
+}
+
+// GetClientChains is a free data retrieval call binding the contract method 0x41a3745b.
+//
+// Solidity: function getClientChains() view returns(bool, uint32[])
+func (_Assets *AssetsCallerSession) GetClientChains() (bool, []uint32, error) {
+	return _Assets.Contract.GetClientChains(&_Assets.CallOpts)
+}
+
+// IsRegisteredClientChain is a free data retrieval call binding the contract method 0x6b67d7f7.
+//
+// Solidity: function isRegisteredClientChain(uint32 clientChainID) view returns(bool success, bool isRegistered)
+func (_Assets *AssetsCaller) IsRegisteredClientChain(opts *bind.CallOpts, clientChainID uint32) (struct {
+	Success      bool
+	IsRegistered bool
+}, error) {
+	var out []interface{}
+	err := _Assets.contract.Call(opts, &out, "isRegisteredClientChain", clientChainID)
+
+	outstruct := new(struct {
+		Success      bool
+		IsRegistered bool
+	})
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.Success = *abi.ConvertType(out[0], new(bool)).(*bool)
+	outstruct.IsRegistered = *abi.ConvertType(out[1], new(bool)).(*bool)
+
+	return *outstruct, err
+
+}
+
+// IsRegisteredClientChain is a free data retrieval call binding the contract method 0x6b67d7f7.
+//
+// Solidity: function isRegisteredClientChain(uint32 clientChainID) view returns(bool success, bool isRegistered)
+func (_Assets *AssetsSession) IsRegisteredClientChain(clientChainID uint32) (struct {
+	Success      bool
+	IsRegistered bool
+}, error) {
+	return _Assets.Contract.IsRegisteredClientChain(&_Assets.CallOpts, clientChainID)
+}
+
+// IsRegisteredClientChain is a free data retrieval call binding the contract method 0x6b67d7f7.
+//
+// Solidity: function isRegisteredClientChain(uint32 clientChainID) view returns(bool success, bool isRegistered)
+func (_Assets *AssetsCallerSession) IsRegisteredClientChain(clientChainID uint32) (struct {
+	Success      bool
+	IsRegistered bool
+}, error) {
+	return _Assets.Contract.IsRegisteredClientChain(&_Assets.CallOpts, clientChainID)
+}
+
+// DepositTo is a paid mutator transaction binding the contract method 0xfc5b72e2.
+//
+// Solidity: function depositTo(uint32 clientChainID, bytes assetsAddress, bytes stakerAddress, uint256 opAmount) returns(bool success, uint256 latestAssetState)
+func (_Assets *AssetsTransactor) DepositTo(opts *bind.TransactOpts, clientChainID uint32, assetsAddress []byte, stakerAddress []byte, opAmount *big.Int) (*types.Transaction, error) {
+	return _Assets.contract.Transact(opts, "depositTo", clientChainID, assetsAddress, stakerAddress, opAmount)
+}
+
+// DepositTo is a paid mutator transaction binding the contract method 0xfc5b72e2.
+//
+// Solidity: function depositTo(uint32 clientChainID, bytes assetsAddress, bytes stakerAddress, uint256 opAmount) returns(bool success, uint256 latestAssetState)
+func (_Assets *AssetsSession) DepositTo(clientChainID uint32, assetsAddress []byte, stakerAddress []byte, opAmount *big.Int) (*types.Transaction, error) {
+	return _Assets.Contract.DepositTo(&_Assets.TransactOpts, clientChainID, assetsAddress, stakerAddress, opAmount)
+}
+
+// DepositTo is a paid mutator transaction binding the contract method 0xfc5b72e2.
+//
+// Solidity: function depositTo(uint32 clientChainID, bytes assetsAddress, bytes stakerAddress, uint256 opAmount) returns(bool success, uint256 latestAssetState)
+func (_Assets *AssetsTransactorSession) DepositTo(clientChainID uint32, assetsAddress []byte, stakerAddress []byte, opAmount *big.Int) (*types.Transaction, error) {
+	return _Assets.Contract.DepositTo(&_Assets.TransactOpts, clientChainID, assetsAddress, stakerAddress, opAmount)
+}
+
+// RegisterOrUpdateClientChain is a paid mutator transaction binding the contract method 0x1b315b52.
+//
+// Solidity: function registerOrUpdateClientChain(uint32 clientChainID, uint8 addressLength, string name, string metaInfo, string signatureType) returns(bool success, bool updated)
+func (_Assets *AssetsTransactor) RegisterOrUpdateClientChain(opts *bind.TransactOpts, clientChainID uint32, addressLength uint8, name string, metaInfo string, signatureType string) (*types.Transaction, error) {
+	return _Assets.contract.Transact(opts, "registerOrUpdateClientChain", clientChainID, addressLength, name, metaInfo, signatureType)
+}
+
+// RegisterOrUpdateClientChain is a paid mutator transaction binding the contract method 0x1b315b52.
+//
+// Solidity: function registerOrUpdateClientChain(uint32 clientChainID, uint8 addressLength, string name, string metaInfo, string signatureType) returns(bool success, bool updated)
+func (_Assets *AssetsSession) RegisterOrUpdateClientChain(clientChainID uint32, addressLength uint8, name string, metaInfo string, signatureType string) (*types.Transaction, error) {
+	return _Assets.Contract.RegisterOrUpdateClientChain(&_Assets.TransactOpts, clientChainID, addressLength, name, metaInfo, signatureType)
+}
+
+// RegisterOrUpdateClientChain is a paid mutator transaction binding the contract method 0x1b315b52.
+//
+// Solidity: function registerOrUpdateClientChain(uint32 clientChainID, uint8 addressLength, string name, string metaInfo, string signatureType) returns(bool success, bool updated)
+func (_Assets *AssetsTransactorSession) RegisterOrUpdateClientChain(clientChainID uint32, addressLength uint8, name string, metaInfo string, signatureType string) (*types.Transaction, error) {
+	return _Assets.Contract.RegisterOrUpdateClientChain(&_Assets.TransactOpts, clientChainID, addressLength, name, metaInfo, signatureType)
+}
+
+// RegisterOrUpdateTokens is a paid mutator transaction binding the contract method 0xbf49cb71.
+//
+// Solidity: function registerOrUpdateTokens(uint32 clientChainID, bytes token, uint8 decimals, uint256 tvlLimit, string name, string metaData) returns(bool success, bool updated)
+func (_Assets *AssetsTransactor) RegisterOrUpdateTokens(opts *bind.TransactOpts, clientChainID uint32, token []byte, decimals uint8, tvlLimit *big.Int, name string, metaData string) (*types.Transaction, error) {
+	return _Assets.contract.Transact(opts, "registerOrUpdateTokens", clientChainID, token, decimals, tvlLimit, name, metaData)
+}
+
+// RegisterOrUpdateTokens is a paid mutator transaction binding the contract method 0xbf49cb71.
+//
+// Solidity: function registerOrUpdateTokens(uint32 clientChainID, bytes token, uint8 decimals, uint256 tvlLimit, string name, string metaData) returns(bool success, bool updated)
+func (_Assets *AssetsSession) RegisterOrUpdateTokens(clientChainID uint32, token []byte, decimals uint8, tvlLimit *big.Int, name string, metaData string) (*types.Transaction, error) {
+	return _Assets.Contract.RegisterOrUpdateTokens(&_Assets.TransactOpts, clientChainID, token, decimals, tvlLimit, name, metaData)
+}
+
+// RegisterOrUpdateTokens is a paid mutator transaction binding the contract method 0xbf49cb71.
+//
+// Solidity: function registerOrUpdateTokens(uint32 clientChainID, bytes token, uint8 decimals, uint256 tvlLimit, string name, string metaData) returns(bool success, bool updated)
+func (_Assets *AssetsTransactorSession) RegisterOrUpdateTokens(clientChainID uint32, token []byte, decimals uint8, tvlLimit *big.Int, name string, metaData string) (*types.Transaction, error) {
+	return _Assets.Contract.RegisterOrUpdateTokens(&_Assets.TransactOpts, clientChainID, token, decimals, tvlLimit, name, metaData)
+}
+
+// WithdrawPrincipal is a paid mutator transaction binding the contract method 0x6f233c6b.
+//
+// Solidity: function withdrawPrincipal(uint32 clientChainID, bytes assetsAddress, bytes withdrawAddress, uint256 opAmount) returns(bool success, uint256 latestAssetState)
+func (_Assets *AssetsTransactor) WithdrawPrincipal(opts *bind.TransactOpts, clientChainID uint32, assetsAddress []byte, withdrawAddress []byte, opAmount *big.Int) (*types.Transaction, error) {
+	return _Assets.contract.Transact(opts, "withdrawPrincipal", clientChainID, assetsAddress, withdrawAddress, opAmount)
+}
+
+// WithdrawPrincipal is a paid mutator transaction binding the contract method 0x6f233c6b.
+//
+// Solidity: function withdrawPrincipal(uint32 clientChainID, bytes assetsAddress, bytes withdrawAddress, uint256 opAmount) returns(bool success, uint256 latestAssetState)
+func (_Assets *AssetsSession) WithdrawPrincipal(clientChainID uint32, assetsAddress []byte, withdrawAddress []byte, opAmount *big.Int) (*types.Transaction, error) {
+	return _Assets.Contract.WithdrawPrincipal(&_Assets.TransactOpts, clientChainID, assetsAddress, withdrawAddress, opAmount)
+}
+
+// WithdrawPrincipal is a paid mutator transaction binding the contract method 0x6f233c6b.
+//
+// Solidity: function withdrawPrincipal(uint32 clientChainID, bytes assetsAddress, bytes withdrawAddress, uint256 opAmount) returns(bool success, uint256 latestAssetState)
+func (_Assets *AssetsTransactorSession) WithdrawPrincipal(clientChainID uint32, assetsAddress []byte, withdrawAddress []byte, opAmount *big.Int) (*types.Transaction, error) {
+	return _Assets.Contract.WithdrawPrincipal(&_Assets.TransactOpts, clientChainID, assetsAddress, withdrawAddress, opAmount)
+}

--- a/precompiles/delegation/delegation_binding.go
+++ b/precompiles/delegation/delegation_binding.go
@@ -1,0 +1,256 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package delegation
+
+import (
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+)
+
+// DelegationABI is the input ABI used to generate the binding from.
+const DelegationABI = "[{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"clientChainID\",\"type\":\"uint32\"},{\"internalType\":\"bytes\",\"name\":\"staker\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"operator\",\"type\":\"bytes\"}],\"name\":\"associateOperatorWithStaker\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"success\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"clientChainID\",\"type\":\"uint32\"},{\"internalType\":\"uint64\",\"name\":\"lzNonce\",\"type\":\"uint64\"},{\"internalType\":\"bytes\",\"name\":\"assetsAddress\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"stakerAddress\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"operatorAddr\",\"type\":\"bytes\"},{\"internalType\":\"uint256\",\"name\":\"opAmount\",\"type\":\"uint256\"}],\"name\":\"delegateToThroughClientChain\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"success\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"clientChainID\",\"type\":\"uint32\"},{\"internalType\":\"bytes\",\"name\":\"staker\",\"type\":\"bytes\"}],\"name\":\"dissociateOperatorFromStaker\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"success\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"clientChainID\",\"type\":\"uint32\"},{\"internalType\":\"uint64\",\"name\":\"lzNonce\",\"type\":\"uint64\"},{\"internalType\":\"bytes\",\"name\":\"assetsAddress\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"stakerAddress\",\"type\":\"bytes\"},{\"internalType\":\"bytes\",\"name\":\"operatorAddr\",\"type\":\"bytes\"},{\"internalType\":\"uint256\",\"name\":\"opAmount\",\"type\":\"uint256\"}],\"name\":\"undelegateFromThroughClientChain\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"success\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]"
+
+// Delegation is an auto generated Go binding around an Ethereum contract.
+type Delegation struct {
+	DelegationCaller     // Read-only binding to the contract
+	DelegationTransactor // Write-only binding to the contract
+	DelegationFilterer   // Log filterer for contract events
+}
+
+// DelegationCaller is an auto generated read-only Go binding around an Ethereum contract.
+type DelegationCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// DelegationTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type DelegationTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// DelegationFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type DelegationFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// DelegationSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type DelegationSession struct {
+	Contract     *Delegation       // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// DelegationCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type DelegationCallerSession struct {
+	Contract *DelegationCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts     // Call options to use throughout this session
+}
+
+// DelegationTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type DelegationTransactorSession struct {
+	Contract     *DelegationTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts     // Transaction auth options to use throughout this session
+}
+
+// DelegationRaw is an auto generated low-level Go binding around an Ethereum contract.
+type DelegationRaw struct {
+	Contract *Delegation // Generic contract binding to access the raw methods on
+}
+
+// DelegationCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type DelegationCallerRaw struct {
+	Contract *DelegationCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// DelegationTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type DelegationTransactorRaw struct {
+	Contract *DelegationTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewDelegation creates a new instance of Delegation, bound to a specific deployed contract.
+func NewDelegation(address common.Address, backend bind.ContractBackend) (*Delegation, error) {
+	contract, err := bindDelegation(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &Delegation{DelegationCaller: DelegationCaller{contract: contract}, DelegationTransactor: DelegationTransactor{contract: contract}, DelegationFilterer: DelegationFilterer{contract: contract}}, nil
+}
+
+// NewDelegationCaller creates a new read-only instance of Delegation, bound to a specific deployed contract.
+func NewDelegationCaller(address common.Address, caller bind.ContractCaller) (*DelegationCaller, error) {
+	contract, err := bindDelegation(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &DelegationCaller{contract: contract}, nil
+}
+
+// NewDelegationTransactor creates a new write-only instance of Delegation, bound to a specific deployed contract.
+func NewDelegationTransactor(address common.Address, transactor bind.ContractTransactor) (*DelegationTransactor, error) {
+	contract, err := bindDelegation(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &DelegationTransactor{contract: contract}, nil
+}
+
+// NewDelegationFilterer creates a new log filterer instance of Delegation, bound to a specific deployed contract.
+func NewDelegationFilterer(address common.Address, filterer bind.ContractFilterer) (*DelegationFilterer, error) {
+	contract, err := bindDelegation(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &DelegationFilterer{contract: contract}, nil
+}
+
+// bindDelegation binds a generic wrapper to an already deployed contract.
+func bindDelegation(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := abi.JSON(strings.NewReader(DelegationABI))
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_Delegation *DelegationRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _Delegation.Contract.DelegationCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_Delegation *DelegationRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Delegation.Contract.DelegationTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_Delegation *DelegationRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _Delegation.Contract.DelegationTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_Delegation *DelegationCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _Delegation.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_Delegation *DelegationTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Delegation.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_Delegation *DelegationTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _Delegation.Contract.contract.Transact(opts, method, params...)
+}
+
+// AssociateOperatorWithStaker is a paid mutator transaction binding the contract method 0xf221f9e7.
+//
+// Solidity: function associateOperatorWithStaker(uint32 clientChainID, bytes staker, bytes operator) returns(bool success)
+func (_Delegation *DelegationTransactor) AssociateOperatorWithStaker(opts *bind.TransactOpts, clientChainID uint32, staker []byte, operator []byte) (*types.Transaction, error) {
+	return _Delegation.contract.Transact(opts, "associateOperatorWithStaker", clientChainID, staker, operator)
+}
+
+// AssociateOperatorWithStaker is a paid mutator transaction binding the contract method 0xf221f9e7.
+//
+// Solidity: function associateOperatorWithStaker(uint32 clientChainID, bytes staker, bytes operator) returns(bool success)
+func (_Delegation *DelegationSession) AssociateOperatorWithStaker(clientChainID uint32, staker []byte, operator []byte) (*types.Transaction, error) {
+	return _Delegation.Contract.AssociateOperatorWithStaker(&_Delegation.TransactOpts, clientChainID, staker, operator)
+}
+
+// AssociateOperatorWithStaker is a paid mutator transaction binding the contract method 0xf221f9e7.
+//
+// Solidity: function associateOperatorWithStaker(uint32 clientChainID, bytes staker, bytes operator) returns(bool success)
+func (_Delegation *DelegationTransactorSession) AssociateOperatorWithStaker(clientChainID uint32, staker []byte, operator []byte) (*types.Transaction, error) {
+	return _Delegation.Contract.AssociateOperatorWithStaker(&_Delegation.TransactOpts, clientChainID, staker, operator)
+}
+
+// DelegateToThroughClientChain is a paid mutator transaction binding the contract method 0x910f0cda.
+//
+// Solidity: function delegateToThroughClientChain(uint32 clientChainID, uint64 lzNonce, bytes assetsAddress, bytes stakerAddress, bytes operatorAddr, uint256 opAmount) returns(bool success)
+func (_Delegation *DelegationTransactor) DelegateToThroughClientChain(opts *bind.TransactOpts, clientChainID uint32, lzNonce uint64, assetsAddress []byte, stakerAddress []byte, operatorAddr []byte, opAmount *big.Int) (*types.Transaction, error) {
+	return _Delegation.contract.Transact(opts, "delegateToThroughClientChain", clientChainID, lzNonce, assetsAddress, stakerAddress, operatorAddr, opAmount)
+}
+
+// DelegateToThroughClientChain is a paid mutator transaction binding the contract method 0x910f0cda.
+//
+// Solidity: function delegateToThroughClientChain(uint32 clientChainID, uint64 lzNonce, bytes assetsAddress, bytes stakerAddress, bytes operatorAddr, uint256 opAmount) returns(bool success)
+func (_Delegation *DelegationSession) DelegateToThroughClientChain(clientChainID uint32, lzNonce uint64, assetsAddress []byte, stakerAddress []byte, operatorAddr []byte, opAmount *big.Int) (*types.Transaction, error) {
+	return _Delegation.Contract.DelegateToThroughClientChain(&_Delegation.TransactOpts, clientChainID, lzNonce, assetsAddress, stakerAddress, operatorAddr, opAmount)
+}
+
+// DelegateToThroughClientChain is a paid mutator transaction binding the contract method 0x910f0cda.
+//
+// Solidity: function delegateToThroughClientChain(uint32 clientChainID, uint64 lzNonce, bytes assetsAddress, bytes stakerAddress, bytes operatorAddr, uint256 opAmount) returns(bool success)
+func (_Delegation *DelegationTransactorSession) DelegateToThroughClientChain(clientChainID uint32, lzNonce uint64, assetsAddress []byte, stakerAddress []byte, operatorAddr []byte, opAmount *big.Int) (*types.Transaction, error) {
+	return _Delegation.Contract.DelegateToThroughClientChain(&_Delegation.TransactOpts, clientChainID, lzNonce, assetsAddress, stakerAddress, operatorAddr, opAmount)
+}
+
+// DissociateOperatorFromStaker is a paid mutator transaction binding the contract method 0x1a004d5a.
+//
+// Solidity: function dissociateOperatorFromStaker(uint32 clientChainID, bytes staker) returns(bool success)
+func (_Delegation *DelegationTransactor) DissociateOperatorFromStaker(opts *bind.TransactOpts, clientChainID uint32, staker []byte) (*types.Transaction, error) {
+	return _Delegation.contract.Transact(opts, "dissociateOperatorFromStaker", clientChainID, staker)
+}
+
+// DissociateOperatorFromStaker is a paid mutator transaction binding the contract method 0x1a004d5a.
+//
+// Solidity: function dissociateOperatorFromStaker(uint32 clientChainID, bytes staker) returns(bool success)
+func (_Delegation *DelegationSession) DissociateOperatorFromStaker(clientChainID uint32, staker []byte) (*types.Transaction, error) {
+	return _Delegation.Contract.DissociateOperatorFromStaker(&_Delegation.TransactOpts, clientChainID, staker)
+}
+
+// DissociateOperatorFromStaker is a paid mutator transaction binding the contract method 0x1a004d5a.
+//
+// Solidity: function dissociateOperatorFromStaker(uint32 clientChainID, bytes staker) returns(bool success)
+func (_Delegation *DelegationTransactorSession) DissociateOperatorFromStaker(clientChainID uint32, staker []byte) (*types.Transaction, error) {
+	return _Delegation.Contract.DissociateOperatorFromStaker(&_Delegation.TransactOpts, clientChainID, staker)
+}
+
+// UndelegateFromThroughClientChain is a paid mutator transaction binding the contract method 0xea3a6510.
+//
+// Solidity: function undelegateFromThroughClientChain(uint32 clientChainID, uint64 lzNonce, bytes assetsAddress, bytes stakerAddress, bytes operatorAddr, uint256 opAmount) returns(bool success)
+func (_Delegation *DelegationTransactor) UndelegateFromThroughClientChain(opts *bind.TransactOpts, clientChainID uint32, lzNonce uint64, assetsAddress []byte, stakerAddress []byte, operatorAddr []byte, opAmount *big.Int) (*types.Transaction, error) {
+	return _Delegation.contract.Transact(opts, "undelegateFromThroughClientChain", clientChainID, lzNonce, assetsAddress, stakerAddress, operatorAddr, opAmount)
+}
+
+// UndelegateFromThroughClientChain is a paid mutator transaction binding the contract method 0xea3a6510.
+//
+// Solidity: function undelegateFromThroughClientChain(uint32 clientChainID, uint64 lzNonce, bytes assetsAddress, bytes stakerAddress, bytes operatorAddr, uint256 opAmount) returns(bool success)
+func (_Delegation *DelegationSession) UndelegateFromThroughClientChain(clientChainID uint32, lzNonce uint64, assetsAddress []byte, stakerAddress []byte, operatorAddr []byte, opAmount *big.Int) (*types.Transaction, error) {
+	return _Delegation.Contract.UndelegateFromThroughClientChain(&_Delegation.TransactOpts, clientChainID, lzNonce, assetsAddress, stakerAddress, operatorAddr, opAmount)
+}
+
+// UndelegateFromThroughClientChain is a paid mutator transaction binding the contract method 0xea3a6510.
+//
+// Solidity: function undelegateFromThroughClientChain(uint32 clientChainID, uint64 lzNonce, bytes assetsAddress, bytes stakerAddress, bytes operatorAddr, uint256 opAmount) returns(bool success)
+func (_Delegation *DelegationTransactorSession) UndelegateFromThroughClientChain(clientChainID uint32, lzNonce uint64, assetsAddress []byte, stakerAddress []byte, operatorAddr []byte, opAmount *big.Int) (*types.Transaction, error) {
+	return _Delegation.Contract.UndelegateFromThroughClientChain(&_Delegation.TransactOpts, clientChainID, lzNonce, assetsAddress, stakerAddress, operatorAddr, opAmount)
+}

--- a/precompiles/testutil/precompile_test.go
+++ b/precompiles/testutil/precompile_test.go
@@ -1,0 +1,233 @@
+//go:build skiptest
+
+// It's used to facilitate the precompile test without depending on the client chain and Exocore
+// gateway contract. This test depends on a running local node, so set the ignore flag to skip the
+//  tests. You can execute this test by clicking in an IDE or by using the `go test` command
+// These tests can be referred to when implementing automated integration testing tools, which can reduce
+// the test workload for the basic precompile functions when the code has some significant changed.
+
+package testutil_test
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"fmt"
+	"github.com/ExocoreNetwork/exocore/precompiles/assets"
+	"github.com/ExocoreNetwork/exocore/precompiles/delegation"
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	common2 "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/stretchr/testify/assert"
+	"math/big"
+	"strings"
+	"testing"
+	"time"
+)
+
+type BasicInfoToSendTx struct {
+	ctx      context.Context
+	sk       *ecdsa.PrivateKey
+	caller   common2.Address
+	signer   types.Signer
+	ethC     *ethclient.Client
+	nonce    uint64
+	GasPrice *big.Int
+	GasLimit uint64
+}
+
+var ExocorePrecompileGaLimit = uint64(500000)
+
+func PaddingAddressTo32(address common2.Address) []byte {
+	paddingLen := 32 - len(address)
+	ret := make([]byte, len(address))
+	copy(ret, address[:])
+	for i := 0; i < paddingLen; i++ {
+		ret = append(ret, 0)
+	}
+	fmt.Println("the ret is:", hexutil.Encode(ret))
+	return ret
+}
+
+func SendTxPreparation(t *testing.T) BasicInfoToSendTx {
+	// this is the private key of local funded address
+	privateKey := "D196DCA836F8AC2FFF45B3C9F0113825CCBB33FA1B39737B948503B263ED75AE"
+	sk, err := crypto.HexToECDSA(privateKey)
+	assert.NoError(t, err)
+	callAddr := crypto.PubkeyToAddress(sk.PublicKey)
+
+	ctx := context.Background()
+	exocoreNode := "http://127.0.0.1:8545"
+	c, err := rpc.DialContext(ctx, exocoreNode)
+	assert.NoError(t, err)
+	ethC := ethclient.NewClient(c)
+	chainID, err := ethC.ChainID(ctx)
+	assert.NoError(t, err)
+	signer := types.LatestSignerForChainID(chainID)
+
+	gasLimit := ExocorePrecompileGaLimit
+	nonce, err := ethC.NonceAt(ctx, callAddr, nil)
+	assert.NoError(t, err)
+	gasPrice, err := ethC.SuggestGasPrice(ctx)
+	assert.NoError(t, err)
+	return BasicInfoToSendTx{
+		ctx:      ctx,
+		sk:       sk,
+		caller:   callAddr,
+		ethC:     ethC,
+		signer:   signer,
+		nonce:    nonce,
+		GasLimit: gasLimit,
+		GasPrice: gasPrice,
+	}
+}
+func SignAndSendTx(basicInfo *BasicInfoToSendTx, contractAddr *common2.Address, data []byte, t *testing.T) {
+	retTx := types.NewTx(&types.LegacyTx{
+		Nonce:    basicInfo.nonce,
+		To:       contractAddr,
+		Value:    big.NewInt(0),
+		Gas:      basicInfo.GasLimit,
+		GasPrice: basicInfo.GasPrice,
+		Data:     data,
+	})
+
+	signTx, err := types.SignTx(retTx, basicInfo.signer, basicInfo.sk)
+	assert.NoError(t, err)
+	fmt.Println("the txID is:", signTx.Hash().String())
+	msg := ethereum.CallMsg{
+		From: basicInfo.caller,
+		To:   retTx.To(),
+		Data: retTx.Data(),
+	}
+	_, err = basicInfo.ethC.CallContract(context.Background(), msg, nil)
+	assert.NoError(t, err)
+
+	err = basicInfo.ethC.SendTransaction(basicInfo.ctx, signTx)
+	assert.NoError(t, err)
+
+	time.Sleep(20 * time.Second)
+
+	receipt, err := basicInfo.ethC.TransactionReceipt(basicInfo.ctx, signTx.Hash())
+	assert.NoError(t, err)
+	assert.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
+	fmt.Println("the block height is:", receipt.BlockNumber)
+}
+
+func Test_ExocoreClient(t *testing.T) {
+	basicInfo := SendTxPreparation(t)
+
+	blockNumber, err := basicInfo.ethC.BlockNumber(basicInfo.ctx)
+	assert.NoError(t, err)
+	fmt.Println("the blockNumber is:", blockNumber)
+
+	balance, err := basicInfo.ethC.BalanceAt(basicInfo.ctx, basicInfo.caller, nil)
+	assert.NoError(t, err)
+	fmt.Println("the balance is:", balance)
+
+	//assetsAddr := common2.HexToAddress("0x0000000000000000000000000000000000000800")
+	contractBytes, err := basicInfo.ethC.CodeAt(basicInfo.ctx, basicInfo.caller, nil)
+	assert.NoError(t, err)
+	fmt.Println("the contractBytes is:", hexutil.Encode(contractBytes))
+}
+
+func Test_CheckTxStatus(t *testing.T) {
+	basicInfo := SendTxPreparation(t)
+	txID := common2.HexToHash("0x19d44adc35607e0187300bfedca35a3da11e7684a553f7837294054c3aa3d147")
+	tx, isPending, err := basicInfo.ethC.TransactionByHash(basicInfo.ctx, txID)
+	assert.NoError(t, err)
+	fmt.Println("isPending", isPending)
+	fmt.Println("the tx is:", tx.Hash())
+
+	receipt, err := basicInfo.ethC.TransactionReceipt(basicInfo.ctx, txID)
+	assert.NoError(t, err)
+	assert.Equal(t, types.ReceiptStatusSuccessful, receipt.Status)
+	fmt.Println("the block height is:", receipt.BlockNumber)
+}
+
+func Test_RegisterOrUpdateClientChain(t *testing.T) {
+	basicInfo := SendTxPreparation(t)
+	contractAddr := common2.HexToAddress("0x0000000000000000000000000000000000000804")
+	assetsAbi, err := abi.JSON(strings.NewReader(assets.AssetsABI))
+	assert.NoError(t, err)
+
+	clientChainID := uint32(111)
+	addressLength := uint8(20)
+	name := "testClientChain"
+	metaInfo := "it's a test client chain"
+	signatureType := "ecdsa"
+	data, err := assetsAbi.Pack("registerOrUpdateClientChain", clientChainID, addressLength, name, metaInfo, signatureType)
+	assert.NoError(t, err)
+	SignAndSendTx(&basicInfo, &contractAddr, data, t)
+}
+
+func Test_RegisterOrUpdateTokens(t *testing.T) {
+	basicInfo := SendTxPreparation(t)
+	contractAddr := common2.HexToAddress("0x0000000000000000000000000000000000000804")
+	assetsAbi, err := abi.JSON(strings.NewReader(assets.AssetsABI))
+	assert.NoError(t, err)
+
+	clientChainID := uint32(101)
+	testTokenAddr0 := common2.HexToAddress("0xb82381a3fbd3fafa77b3a7be693342618240067b")
+	decimal := uint8(8)
+	tvlLimit := big.NewInt(3000000000000000000)
+	name := "WSTETH"
+	metaInfo := "Wrapped STETH"
+
+	data, err := assetsAbi.Pack("registerOrUpdateTokens", clientChainID, PaddingAddressTo32(testTokenAddr0), decimal, tvlLimit, name, metaInfo)
+
+	assert.NoError(t, err)
+	SignAndSendTx(&basicInfo, &contractAddr, data, t)
+}
+
+func Test_Deposit(t *testing.T) {
+	basicInfo := SendTxPreparation(t)
+
+	stakerAddr := common2.HexToAddress("0x217F1887cCE09BFFc4194cca5d561Bc447298d24")
+	contractAddr := common2.HexToAddress("0x0000000000000000000000000000000000000804")
+	assetsAbi, err := abi.JSON(strings.NewReader(assets.AssetsABI))
+	assert.NoError(t, err)
+	assetAddr := common2.HexToAddress("0xb82381a3fbd3fafa77b3a7be693342618240067b")
+	opAmount := big.NewInt(0).Exp(big.NewInt(100), big.NewInt(8), nil)
+	fmt.Println("the opAmount is:", opAmount)
+	clientChainID := uint32(101)
+
+	data, err := assetsAbi.Pack("depositTo", clientChainID, PaddingAddressTo32(assetAddr), PaddingAddressTo32(stakerAddr), opAmount)
+	SignAndSendTx(&basicInfo, &contractAddr, data, t)
+}
+
+func Test_Delegate(t *testing.T) {
+	basicInfo := SendTxPreparation(t)
+
+	stakerAddr := common2.HexToAddress("0x217F1887cCE09BFFc4194cca5d561Bc447298d24")
+	contractAddr := common2.HexToAddress("0x0000000000000000000000000000000000000805")
+	delegationAbi, err := abi.JSON(strings.NewReader(delegation.DelegationABI))
+	assetAddr := common2.HexToAddress("0xb82381a3fbd3fafa77b3a7be693342618240067b")
+	opAmount := big.NewInt(0).Exp(big.NewInt(100), big.NewInt(8), nil)
+	clientChainID := uint32(101)
+	// todo: need to ensure the operator address has been registered
+	operatorAddr := "exo18cggcpvwspnd5c6ny8wrqxpffj5zmhklprtnph"
+
+	// using the nonce of caller as the layer zero nonce
+	data, err := delegationAbi.Pack("delegateToThroughClientChain", clientChainID, basicInfo.nonce, PaddingAddressTo32(assetAddr), PaddingAddressTo32(stakerAddr), []byte(operatorAddr), opAmount)
+	assert.NoError(t, err)
+	SignAndSendTx(&basicInfo, &contractAddr, data, t)
+}
+
+func Test_AssociateOperatorWithStaker(t *testing.T) {
+	basicInfo := SendTxPreparation(t)
+	stakerAddr := common2.HexToAddress("0x217F1887cCE09BFFc4194cca5d561Bc447298d24")
+	clientChainID := uint32(101)
+	contractAddr := common2.HexToAddress("0x0000000000000000000000000000000000000805")
+	delegationAbi, err := abi.JSON(strings.NewReader(delegation.DelegationABI))
+	// todo: need to ensure the operator address has been registered
+	operatorAddr := "exo18cggcpvwspnd5c6ny8wrqxpffj5zmhklprtnph"
+
+	// using the nonce of caller as the layer zero nonce
+	data, err := delegationAbi.Pack("associateOperatorWithStaker", clientChainID, PaddingAddressTo32(stakerAddr), []byte(operatorAddr))
+	assert.NoError(t, err)
+	SignAndSendTx(&basicInfo, &contractAddr, data, t)
+}

--- a/x/assets/types/genesis.go
+++ b/x/assets/types/genesis.go
@@ -49,13 +49,6 @@ func (gs GenesisState) Validate() error {
 				i, info.MetaInfo, MaxChainTokenMetaInfoLength,
 			)
 		}
-		if info.MetaInfo == "" || len(info.MetaInfo) > MaxChainMetaInfoLength {
-			return errorsmod.Wrapf(
-				ErrInvalidGenesisData,
-				"nil meta info or too long for chain %d, maxLength:%d",
-				i, MaxChainMetaInfoLength,
-			)
-		}
 		// this is our primary method of cross-chain communication.
 		if info.LayerZeroChainID == 0 {
 			return errorsmod.Wrapf(

--- a/x/assets/types/genesis.go
+++ b/x/assets/types/genesis.go
@@ -49,6 +49,13 @@ func (gs GenesisState) Validate() error {
 				i, info.MetaInfo, MaxChainTokenMetaInfoLength,
 			)
 		}
+		if info.MetaInfo == "" || len(info.MetaInfo) > MaxChainMetaInfoLength {
+			return errorsmod.Wrapf(
+				ErrInvalidGenesisData,
+				"nil meta info or too long for chain %d, maxLength:%d",
+				i, MaxChainMetaInfoLength,
+			)
+		}
 		// this is our primary method of cross-chain communication.
 		if info.LayerZeroChainID == 0 {
 			return errorsmod.Wrapf(


### PR DESCRIPTION
## Description

This PR adds a precompile test using the local node to facilitate daily testing. It subsumes the [#PR116](https://github.com/ExocoreNetwork/exocore/pull/116), so it should be rebased after the #PR116 is merged.

This PR can be referred to when implementing automated integration testing tools, which can reduce the test workload for the basic precompile functions when the code has some significant changes.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced new functionality for registering client chains and tokens.
  - Added support for handling asset deposits and withdrawals with refined parameter names.

- **Bug Fixes**
  - Improved error messages to provide clearer information on parameter types and lengths.

- **Refactor**
  - Renamed several methods and parameters for better clarity and consistency.

- **Tests**
  - Added a comprehensive suite of tests for the Exocore precompile functionalities.

- **Chores**
  - Updated dependencies to the latest versions for improved stability and security.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->