### PR TITLE
fix(oralce):separate prepareRound from endBlock into beginBlock

### DIFF
--- a/x/oracle/keeper/aggregator/context.go
+++ b/x/oracle/keeper/aggregator/context.go
@@ -218,7 +218,8 @@ func (agc *AggregatorContext) SealRound(ctx sdk.Context, force bool) (success []
 	return success, failed
 }
 
-func (agc *AggregatorContext) PrepareRound(ctx sdk.Context, block uint64) {
+// TODO: test to remove PrepareRound into BeginBlock
+func (agc *AggregatorContext) PrepareRoundBeginBlock(ctx sdk.Context, block uint64) {
 	// block>0 means recache initialization, all roundInfo is empty
 	if block == 0 {
 		block = uint64(ctx.BlockHeight())
@@ -228,15 +229,16 @@ func (agc *AggregatorContext) PrepareRound(ctx sdk.Context, block uint64) {
 		if feederID == 0 {
 			continue
 		}
-		if (feeder.EndBlock > 0 && feeder.EndBlock <= block) || feeder.StartBaseBlock > block {
+		if (feeder.EndBlock > 0 && feeder.EndBlock < block) || feeder.StartBaseBlock >= block {
 			// this feeder is inactive
 			continue
 		}
 
-		delta := block - feeder.StartBaseBlock
+		baseBlock := block - 1
+		delta := baseBlock - feeder.StartBaseBlock
 		left := delta % feeder.Interval
 		count := delta / feeder.Interval
-		latestBasedblock := block - left
+		latestBasedblock := baseBlock - left
 		latestNextRoundID := feeder.StartRoundID + count
 
 		feederIDUint64 := uint64(feederID)

--- a/x/oracle/keeper/aggregator/context_test.go
+++ b/x/oracle/keeper/aggregator/context_test.go
@@ -18,7 +18,7 @@ func TestAggregatorContext(t *testing.T) {
 		Convey("prepare round to gengerate round info of feeders for next block", func() {
 			Convey("pepare within the window", func() {
 				p := patchBlockHeight(12)
-				agc.PrepareRound(ctx, 0)
+				agc.PrepareRoundBeginBlock(ctx, 0)
 
 				Convey("for empty round list", func() {
 					So(*agc.rounds[1], ShouldResemble, roundInfo{10, 2, 1})
@@ -27,9 +27,9 @@ func TestAggregatorContext(t *testing.T) {
 				Convey("update already exist round info", func() {
 					p.Reset()
 					time.Sleep(1 * time.Second)
-					patchBlockHeight(10 + int64(common.MaxNonce))
+					patchBlockHeight(10 + int64(common.MaxNonce) + 1)
 
-					agc.PrepareRound(ctx, 0)
+					agc.PrepareRoundBeginBlock(ctx, 0)
 					So(agc.rounds[1].status, ShouldEqual, 2)
 				})
 				p.Reset()
@@ -37,8 +37,8 @@ func TestAggregatorContext(t *testing.T) {
 			})
 			Convey("pepare outside the window", func() {
 				Convey("for empty round list", func() {
-					p := patchBlockHeight(10 + int64(common.MaxNonce))
-					agc.PrepareRound(ctx, 0)
+					p := patchBlockHeight(10 + int64(common.MaxNonce) + 1)
+					agc.PrepareRoundBeginBlock(ctx, 0)
 					So(agc.rounds[1].status, ShouldEqual, 2)
 					p.Reset()
 					time.Sleep(1 * time.Second)
@@ -46,9 +46,9 @@ func TestAggregatorContext(t *testing.T) {
 			})
 		})
 
-		Convey("seal existed round without any msg recieved", func() {
+		Convey("seal existing round without any msg recieved", func() {
 			p := patchBlockHeight(11)
-			agc.PrepareRound(ctx, 0)
+			agc.PrepareRoundBeginBlock(ctx, 0)
 			Convey("seal when exceed the window", func() {
 				So(agc.rounds[1].status, ShouldEqual, 1)
 				p.Reset()

--- a/x/oracle/keeper/msg_server_create_price.go
+++ b/x/oracle/keeper/msg_server_create_price.go
@@ -18,15 +18,17 @@ func (ms msgServer) CreatePrice(goCtx context.Context, msg *types.MsgCreatePrice
 
 	logger := ms.Keeper.Logger(ctx)
 	if err := checkTimestamp(ctx, msg); err != nil {
+		logger.Info("price proposal timestamp check failed", "error", err, "height", ctx.BlockHeight())
 		return nil, types.ErrPriceProposalFormatInvalid.Wrap(err.Error())
 	}
 
 	newItem, caches, err := GetAggregatorContext(ctx, ms.Keeper).NewCreatePrice(ctx, msg)
 	if err != nil {
+		logger.Info("price proposal failed", "error", err, "height", ctx.BlockHeight())
 		return nil, err
 	}
 
-	logger.Info("add price proposal for aggregation", "feederID", msg.FeederID, "basedBlock", msg.BasedBlock, "proposer", msg.Creator)
+	logger.Info("add price proposal for aggregation", "feederID", msg.FeederID, "basedBlock", msg.BasedBlock, "proposer", msg.Creator, "height", ctx.BlockHeight())
 
 	ctx.EventManager().EmitEvent(sdk.NewEvent(
 		types.EventTypeCreatePrice,
@@ -42,7 +44,7 @@ func (ms msgServer) CreatePrice(goCtx context.Context, msg *types.MsgCreatePrice
 	if newItem != nil {
 		ms.AppendPriceTR(ctx, newItem.TokenID, newItem.PriceTR)
 
-		logger.Info("final price aggregation done", "feederID", msg.FeederID, "roundID", newItem.PriceTR.RoundID, "price", newItem.PriceTR.Price)
+		logger.Info("final price aggregation done", "feederID", msg.FeederID, "roundID", newItem.PriceTR.RoundID, "price", newItem.PriceTR.Price, "height", ctx.BlockHeight())
 
 		ctx.EventManager().EmitEvent(sdk.NewEvent(
 			types.EventTypeCreatePrice,

--- a/x/oracle/keeper/single.go
+++ b/x/oracle/keeper/single.go
@@ -60,7 +60,7 @@ func GetAggregatorContext(ctx sdk.Context, k Keeper) *aggregator.AggregatorConte
 }
 
 func recacheAggregatorContext(ctx sdk.Context, agc *aggregator.AggregatorContext, k Keeper, c *cache.Cache) bool {
-	from := ctx.BlockHeight() - int64(common.MaxNonce)
+	from := ctx.BlockHeight() - int64(common.MaxNonce) + 1
 	to := ctx.BlockHeight() - 1
 
 	h, ok := k.GetValidatorUpdateBlock(ctx)
@@ -71,7 +71,7 @@ func recacheAggregatorContext(ctx sdk.Context, agc *aggregator.AggregatorContext
 	}
 
 	if int64(h.Block) > from {
-		from = int64(h.Block)
+		from = int64(h.Block) + 1
 	}
 
 	totalPower := big.NewInt(0)
@@ -104,7 +104,7 @@ func recacheAggregatorContext(ctx sdk.Context, agc *aggregator.AggregatorContext
 			}
 		}
 
-		agc.PrepareRound(ctx, uint64(from))
+		agc.PrepareRoundBeginBlock(ctx, uint64(from))
 
 		if msgs := recentMsgs[from+1]; msgs != nil {
 			for _, msg := range msgs {
@@ -138,8 +138,6 @@ func recacheAggregatorContext(ctx sdk.Context, agc *aggregator.AggregatorContext
 	if updated := c.GetCache(cache.ItemP(&pRet)); !updated {
 		c.AddCache(cache.ItemP(&pTmp))
 	}
-	// fill params cache
-	agc.PrepareRound(ctx, uint64(to))
 
 	return true
 }
@@ -168,7 +166,7 @@ func initAggregatorContext(ctx sdk.Context, agc *aggregator.AggregatorContext, k
 	// set validatorPower cache
 	c.AddCache(cache.ItemV(validatorPowers))
 
-	agc.PrepareRound(ctx, uint64(ctx.BlockHeight()-1))
+	agc.PrepareRoundBeginBlock(ctx, uint64(ctx.BlockHeight()))
 }
 
 func ResetAggregatorContext() {

--- a/x/oracle/keeper/single.go
+++ b/x/oracle/keeper/single.go
@@ -106,7 +106,7 @@ func recacheAggregatorContext(ctx sdk.Context, agc *aggregator.AggregatorContext
 
 		agc.PrepareRoundBeginBlock(ctx, uint64(from))
 
-		if msgs := recentMsgs[from+1]; msgs != nil {
+		if msgs := recentMsgs[from]; msgs != nil {
 			for _, msg := range msgs {
 				// these messages are retreived for recache, just skip the validation check and fill the memory cache
 				//nolint

--- a/x/oracle/keeper/single.go
+++ b/x/oracle/keeper/single.go
@@ -70,7 +70,7 @@ func recacheAggregatorContext(ctx sdk.Context, agc *aggregator.AggregatorContext
 		return false
 	}
 
-	if int64(h.Block) > from {
+	if int64(h.Block) >= from {
 		from = int64(h.Block) + 1
 	}
 
@@ -117,7 +117,8 @@ func recacheAggregatorContext(ctx sdk.Context, agc *aggregator.AggregatorContext
 				})
 			}
 		}
-		agc.SealRound(ctx, false)
+		ctxReplay := ctx.WithBlockHeight(from)
+		agc.SealRound(ctxReplay, false)
 	}
 
 	if from >= to {

--- a/x/oracle/module.go
+++ b/x/oracle/module.go
@@ -150,7 +150,15 @@ func (am AppModule) ExportGenesis(ctx sdk.Context, cdc codec.JSONCodec) json.Raw
 func (AppModule) ConsensusVersion() uint64 { return 1 }
 
 // BeginBlock contains the logic that is automatically triggered at the beginning of each block
-func (am AppModule) BeginBlock(_ sdk.Context, _ abci.RequestBeginBlock) {}
+func (am AppModule) BeginBlock(ctx sdk.Context, _ abci.RequestBeginBlock) {
+	_ = keeper.GetCaches()
+	agc := keeper.GetAggregatorContext(ctx, am.keeper)
+
+	logger := am.keeper.Logger(ctx)
+
+	logger.Info("prepare for next oracle round of each tokenFeeder")
+	agc.PrepareRoundBeginBlock(ctx, 0)
+}
 
 // EndBlock contains the logic that is automatically triggered at the end of each block
 func (am AppModule) EndBlock(ctx sdk.Context, _ abci.RequestEndBlock) []abci.ValidatorUpdate {
@@ -213,8 +221,6 @@ func (am AppModule) EndBlock(ctx sdk.Context, _ abci.RequestEndBlock) []abci.Val
 	}
 	// TODO: emit events for success sealed rounds(could ignore for v1)
 
-	logger.Info("prepare for next oracle round of each tokenFeeder")
-	agc.PrepareRound(ctx, 0)
 	keeper.ResetAggregatorContextCheckTx()
 
 	// TODO: update params happened during this block for cache, for the case: agc is recached from history and cache'params is set with the latest params by recache, but parmas changed during this block as well. or force agc to be GET first before cache be GET(later approch is better)

--- a/x/oracle/module.go
+++ b/x/oracle/module.go
@@ -156,7 +156,7 @@ func (am AppModule) BeginBlock(ctx sdk.Context, _ abci.RequestBeginBlock) {
 
 	logger := am.keeper.Logger(ctx)
 
-	logger.Info("prepare for next oracle round of each tokenFeeder")
+	logger.Info("prepare for next oracle round of each tokenFeeder", "height", ctx.BlockHeight())
 	agc.PrepareRoundBeginBlock(ctx, 0)
 }
 
@@ -183,7 +183,7 @@ func (am AppModule) EndBlock(ctx sdk.Context, _ abci.RequestEndBlock) []abci.Val
 		agc.SetValidatorPowers(validatorPowers)
 		// TODO: seal all alive round since validatorSet changed here
 		forceSeal = true
-		logger.Info("validator set changed, force seal all active rounds")
+		logger.Info("validator set changed, force seal all active rounds", "height", ctx.BlockHeight())
 	}
 
 	// TODO: for v1 use mode==1, just check the failed feeders
@@ -199,7 +199,6 @@ func (am AppModule) EndBlock(ctx sdk.Context, _ abci.RequestEndBlock) []abci.Val
 		if pTR, ok := am.keeper.GetPriceTRLatest(ctx, tokenID); ok {
 			pTR.RoundID++
 			am.keeper.AppendPriceTR(ctx, tokenID, pTR)
-			logger.Info("add new round with previous price under fail aggregation", "tokenID", tokenID, "roundID", pTR.RoundID)
 			logInfo += fmt.Sprintf(", roundID:%d, price:%s", pTR.RoundID, pTR.Price)
 			event.AppendAttributes(
 				sdk.NewAttribute(types.AttributeKeyRoundID, strconv.FormatUint(pTR.RoundID, 10)),
@@ -216,7 +215,7 @@ func (am AppModule) EndBlock(ctx sdk.Context, _ abci.RequestEndBlock) []abci.Val
 				sdk.NewAttribute(types.AttributeKeyFinalPrice, "-"),
 			)
 		}
-		logger.Info(logInfo)
+		logger.Info(logInfo, "height", ctx.BlockHeight())
 		ctx.EventManager().EmitEvent(event)
 	}
 	// TODO: emit events for success sealed rounds(could ignore for v1)


### PR DESCRIPTION
## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->
Move `prepareRound` from `EndBlock` into `Beginblock`.
Currently we invoke `prepareRound` in the `EndBlock` of every block after all transaction executed. When there're `create-price` transactions in the first block since a node restart(like when a node restart from some height `x`, and some `create-price` messages are included in height `x` by other validators), the `aggregator` will be initialized/recached when the first message executed, this will consume extra gas which will conduct different gasUsed compared to other validators/nodes execution.
In this fix, we put the `prepareRound` into `BeginBlock`. In this way, avoid the initialization of `aggregator` be executed inside transaction.

----

Closes #XXX

<!--
< < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

PR review checkboxes:

I have...

- [ ] added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] included the correct
      [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json)
      in the PR title
- [ ] targeted the correct branch
      (see [PR Targeting](https://github.com/ExocoreNetwork/exocore/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link in the PR description to the relevant issue or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all required CI checks have passed

Code maintenance:

I have...

- [ ] written unit and integration [tests](https://github.com/ExocoreNetwork/exocore/blob/main/CONTRIBUTING.md#testing)
- [ ] added relevant [`godoc`](https://go.dev/blog/godoc) and [code comments](https://blog.jbowen.dev/2019/09/the-magic-of-go-comments/).
- [ ] updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)

______

### Reviewers Checklist

**All** items are required.
Please add a note if the item is not applicable
and please add your handle next to the items reviewed
if you only reviewed selected items.

I have...

- [ ] confirmed the correct
      [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json)
      in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] confirmed that this PR does not change production code

-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced logging for better context during price proposal processing.
   
- **Refactor**
  - Renamed `PrepareRound` method to `PrepareRoundBeginBlock` across various functionalities to improve clarity in block calculation logic.
  
- **Bug Fixes**
  - Adjusted block height calculations to ensure accurate data handling in the aggregator context.
  
- **Chores**
  - Updated methods in `AppModule` to include additional logic for preparing and resetting the oracle round.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->