### PR TITLE
feat:Add feature to query all opted-in operators based on AVS address

### DIFF
--- a/x/operator/keeper/operator.go
+++ b/x/operator/keeper/operator.go
@@ -193,3 +193,22 @@ func (k *Keeper) GetOptedInAVSForOperator(ctx sdk.Context, operatorAddr string) 
 	}
 	return avsList, nil
 }
+
+func (k *Keeper) GetOptedInOperatorListByAVS(ctx sdk.Context, avsAddr string) ([]string, error) {
+	// get all opted-in info
+	store := prefix.NewStore(ctx.KVStore(k.storeKey), operatortypes.KeyPrefixOperatorOptedAVSInfo)
+	iterator := sdk.KVStorePrefixIterator(store, nil)
+	defer iterator.Close()
+
+	operatorList := make([]string, 0)
+	for ; iterator.Valid(); iterator.Next() {
+		keys, err := assetstype.ParseJoinedStoreKey(iterator.Key(), 2)
+		if err != nil {
+			return nil, err
+		}
+		if avsAddr == keys[1] {
+			operatorList = append(operatorList, keys[0])
+		}
+	}
+	return operatorList, nil
+}

--- a/x/operator/keeper/opt_test.go
+++ b/x/operator/keeper/opt_test.go
@@ -144,6 +144,22 @@ func (suite *OperatorTestSuite) TestOptIn() {
 	suite.CheckState(expectedState)
 }
 
+func (suite *OperatorTestSuite) TestOptInList() {
+	suite.prepare()
+	err := suite.App.OperatorKeeper.OptIn(suite.Ctx, suite.operatorAddr, suite.avsAddr)
+	suite.NoError(err)
+	// check if the related state is correct
+	operatorList, err := suite.App.OperatorKeeper.GetOptedInOperatorListByAVS(suite.Ctx, suite.avsAddr)
+	suite.NoError(err)
+	suite.Contains(operatorList, suite.operatorAddr.String())
+
+	avsList, err := suite.App.OperatorKeeper.GetOptedInAVSForOperator(suite.Ctx, suite.operatorAddr.String())
+	suite.NoError(err)
+
+	suite.Contains(avsList, suite.avsAddr)
+
+}
+
 func (suite *OperatorTestSuite) TestOptOut() {
 	suite.prepare()
 	err := suite.App.OperatorKeeper.OptOut(suite.Ctx, suite.operatorAddr, suite.avsAddr)


### PR DESCRIPTION
## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

----

Add feature to query all opted-in operators based on AVS address

<!--
< < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

PR review checkboxes:

I have...

- [ ] added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] included the correct
      [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json)
      in the PR title
- [ ] targeted the correct branch
      (see [PR Targeting](https://github.com/ExocoreNetwork/exocore/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link in the PR description to the relevant issue or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all required CI checks have passed

Code maintenance:

I have...

- [ ] written unit and integration [tests](https://github.com/ExocoreNetwork/exocore/blob/main/CONTRIBUTING.md#testing)
- [ ] added relevant [`godoc`](https://go.dev/blog/godoc) and [code comments](https://blog.jbowen.dev/2019/09/the-magic-of-go-comments/).
- [ ] updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)

______

### Reviewers Checklist

**All** items are required.
Please add a note if the item is not applicable
and please add your handle next to the items reviewed
if you only reviewed selected items.

I have...

- [ ] confirmed the correct
      [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json)
      in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] confirmed that this PR does not change production code

-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new function to retrieve a list of operators who have opted into a specific Asset Verification Service (AVS) address.
  
- **Tests**
	- Added a new test to validate the behavior of the OptIn method and confirm the correct updating of operator and AVS states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->