### PR TITLE
fix(ci): always run Docker build CIs

### DIFF
--- a/.github/workflows/docker-localnet.yml
+++ b/.github/workflows/docker-localnet.yml
@@ -1,13 +1,7 @@
 name: Docker build for localnet
 on:
   pull_request:
-    paths:
-      - networks/local/exocore/Dockerfile
-      - networks/Makefile
   push:
-    paths:
-      - networks/local/exocore/Dockerfile
-      - networks/Makefile
     branches:
       - develop
       - main

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,11 +1,7 @@
 name: Docker build in root directory
 on:
   pull_request:
-    paths:
-      - Dockerfile
   push:
-    paths:
-      - Dockerfile
     branches:
       - develop
       - main

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ WORKDIR /root
 COPY --from=build-env /go/src/github.com/ExocoreNetwork/exocore/build/exocored /usr/bin/exocored
 COPY --from=build-env /go/bin/toml-cli /usr/bin/toml-cli
 
-RUN apk add --no-cache ca-certificates=20240226-r0 libstdc++=13.2.1_git20231014-r0 jq=1.7.1-r0 curl=8.5.0-r0 bash=5.2.21-r0 vim=9.0.2127-r0 lz4=1.9.4-r5 rclone=1.65.0-r3 \
+RUN apk add --no-cache ca-certificates=20240226-r0 libstdc++=13.2.1_git20231014-r0 jq=1.7.1-r0 curl=8.9.0-r0 bash=5.2.21-r0 vim=9.0.2127-r0 lz4=1.9.4-r5 rclone=1.65.0-r3 \
     && addgroup -g 1000 exocore \
     && adduser -S -h /home/exocore -D exocore -u 1000 -G exocore
 

--- a/networks/local/exocore/Dockerfile
+++ b/networks/local/exocore/Dockerfile
@@ -10,7 +10,7 @@ RUN LEDGER_ENABLED=false make build
 
 #####################################
 FROM alpine:3.19 AS run
-RUN apk add --no-cache libstdc++=13.2.1_git20231014-r0 bash=5.2.21-r0 curl=8.5.0-r0 jq=1.7.1-r0 \
+RUN apk add --no-cache libstdc++=13.2.1_git20231014-r0 bash=5.2.21-r0 curl=8.9.0-r0 jq=1.7.1-r0 \
     && addgroup -g 1000 exocore \
     && adduser -S -h /home/exocore -D exocore -u 1000 -G exocore
 EXPOSE 26656 26657 1317 9090 8545 8546


### PR DESCRIPTION
It was wrongly assumed that this CI would only be impacted due to changes in the Dockerfile. However, changes in Alpine Linux repositories, for example, also cause a failure to build.

This change also upgrades the pinned version of curl used in the Dockerfile to one available in the repo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced responsiveness of Docker workflows by allowing builds to trigger on any changes in the repository, rather than being limited to specific files.
  
- **Improvements**
	- Updated the `curl` package version in the Dockerfiles, potentially increasing performance, security, and functionality related to network operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->