### PR TITLE
fix(ci): do not dry run the release on tags

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -23,11 +23,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
-      - name: Set up Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: '1.21.12'
-          check-latest: true
+      - name: Free disk space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
       - name: Release dry run
         run: make release-dry-run
         if: github.event_name == 'pull_request'

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -30,11 +30,13 @@ jobs:
           check-latest: true
       - name: Release dry run
         run: make release-dry-run
+        if: github.event_name == 'pull_request'
       - name: setup release environment
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |-
-          echo 'GITHUB_TOKEN=${{secrets.GITHUB_TOKEN}}' > .release-env    
+          echo 'GITHUB_TOKEN=${{secrets.GITHUB_TOKEN}}' > .release-env
+        if: github.event_name != 'pull_request'
       - name: Release publish
         # Do not publish the release for pull requests.
         if: github.event_name != 'pull_request'


### PR DESCRIPTION
Pushing a new tag causes the binaries to be built twice - firstly as a dry run and secondly as a publish task. This change fixes that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
	- Improved the GitHub Actions workflow for release processes by adding conditional checks for pull requests, enhancing clarity and efficiency in the release management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->