### PR TITLE
fix(oracle): convert the assetID to lowercase format when setting oracle parameter

### DIFF
--- a/testutil/tx/eip712.go
+++ b/testutil/tx/eip712.go
@@ -84,7 +84,8 @@ func PrepareEIP712CosmosTx(
 	if err != nil {
 		return nil, err
 	}
-	fee := legacytx.NewStdFee(txArgs.Gas, txArgs.Fees) //nolint: staticcheck
+	//nolint: staticcheck
+	fee := legacytx.NewStdFee(txArgs.Gas, txArgs.Fees)
 
 	msgs := txArgs.Msgs
 	data := legacytx.StdSignBytes(ctx.ChainID(), accNumber, nonce, 0, fee, msgs, "", nil)

--- a/x/oracle/types/params.go
+++ b/x/oracle/types/params.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"errors"
+	"strings"
 
 	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
 	"gopkg.in/yaml.v2"
@@ -277,6 +278,7 @@ func (p Params) UpdateTokens(currentHeight uint64, tokens ...*Token) (Params, er
 		update := false
 		for tokenID := 1; tokenID < len(p.Tokens); tokenID++ {
 			token := p.Tokens[tokenID]
+			token.AssetID = strings.ToLower(token.AssetID)
 			if token.ChainID == t.ChainID && token.Name == t.Name {
 				// modify existing token
 				update = true


### PR DESCRIPTION
## Description

Address the issue of case sensitivity for assetID when setting oracle parameters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced token management by standardizing asset identifiers to lowercase during updates, improving consistency and preventing case sensitivity issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->