### PR TITLE
fix(lint): ignore the gosec G115 temporarily

### DIFF
--- a/app/ante/cosmos/fees.go
+++ b/app/ante/cosmos/fees.go
@@ -183,8 +183,8 @@ func checkTxFeeWithValidatorMinGasPrices(ctx sdk.Context, feeTx sdk.FeeTx) (sdk.
 			return nil, 0, err
 		}
 	}
-
-	priority := getTxPriority(feeCoins, int64(gas)) //#nosec G701 -- gosec warning about integer overflow is not relevant here
+	// #nosec G115 -- gosec warning about integer overflow is not relevant here
+	priority := getTxPriority(feeCoins, int64(gas))
 	return feeCoins, priority, nil
 }
 
@@ -200,7 +200,7 @@ func checkFeeCoinsAgainstMinGasPrices(ctx sdk.Context, feeCoins sdk.Coins, gas u
 
 	// Determine the required fees by multiplying each required minimum gas
 	// price by the gas limit, where fee = ceil(minGasPrice * gasLimit).
-	glDec := sdk.NewDec(int64(gas)) //#nosec G701 -- gosec warning about integer overflow is not relevant here
+	glDec := sdk.NewDec(int64(gas)) // #nosec G115 -- gosec warning about integer overflow is not relevant here
 	for i, gp := range minGasPrices {
 		fee := gp.Amount.Mul(glDec)
 		requiredFees[i] = sdk.NewCoin(gp.Denom, fee.Ceil().RoundInt())

--- a/app/ante/evm/fee_checker.go
+++ b/app/ante/evm/fee_checker.go
@@ -95,6 +95,7 @@ func NewDynamicFeeChecker(k DynamicFeeEVMKeeper) anteutils.TxFeeChecker {
 func checkTxFeeWithValidatorMinGasPrices(ctx sdk.Context, tx sdk.FeeTx) (sdk.Coins, int64, error) {
 	feeCoins := tx.GetFee()
 	minGasPrices := ctx.MinGasPrices()
+	// #nosec G115
 	gas := int64(tx.GetGas()) //#nosec G701 -- checked for int overflow on ValidateBasic()
 
 	// Ensure that the provided fees meet a minimum threshold for the validator,

--- a/app/tps_counter.go
+++ b/app/tps_counter.go
@@ -108,7 +108,7 @@ func (tpc *tpsCounter) recordValue(ctx context.Context, latest, previous uint64,
 		return 0, nil
 	}
 
-	n := int64(latest - previous)
+	n := int64(latest - previous) // #nosec G115
 	if n < 0 {
 		// Perhaps we exceeded the uint64 limits then wrapped around, for the latest value.
 		// TODO: Perhaps log this?

--- a/precompiles/assets/types.go
+++ b/precompiles/assets/types.go
@@ -37,6 +37,7 @@ func (p Precompile) DepositWithdrawParamsFromInputs(ctx sdk.Context, args []inte
 	if !ok || assetAddr == nil {
 		return nil, fmt.Errorf(exocmn.ErrContractInputParaOrType, 1, "[]byte", args[1])
 	}
+	// #nosec G115
 	if uint32(len(assetAddr)) < clientChainAddrLength {
 		return nil, fmt.Errorf(exocmn.ErrInvalidAddrLength, len(assetAddr), clientChainAddrLength)
 	}
@@ -46,6 +47,7 @@ func (p Precompile) DepositWithdrawParamsFromInputs(ctx sdk.Context, args []inte
 	if !ok || stakerAddr == nil {
 		return nil, fmt.Errorf(exocmn.ErrContractInputParaOrType, 2, "[]byte", args[2])
 	}
+	// #nosec G115
 	if uint32(len(stakerAddr)) < clientChainAddrLength {
 		return nil, fmt.Errorf(exocmn.ErrInvalidAddrLength, len(stakerAddr), clientChainAddrLength)
 	}
@@ -79,6 +81,7 @@ func (p Precompile) ClientChainInfoFromInputs(_ sdk.Context, args []interface{})
 	if addressLength < types.MinClientChainAddrLength {
 		return nil, fmt.Errorf(exocmn.ErrInvalidAddrLength, addressLength, types.MinClientChainAddrLength)
 	}
+	// #nosec G115
 	clientChain.AddressLength = uint32(addressLength)
 
 	name, ok := args[2].(string)
@@ -129,6 +132,7 @@ func (p Precompile) TokenFromInputs(ctx sdk.Context, args []interface{}) (types.
 	if !ok || assetAddr == nil {
 		return types.AssetInfo{}, fmt.Errorf(exocmn.ErrContractInputParaOrType, 1, "[]byte", args[1])
 	}
+	// #nosec G115
 	if uint32(len(assetAddr)) < clientChainAddrLength {
 		return types.AssetInfo{}, fmt.Errorf(exocmn.ErrInvalidAddrLength, len(assetAddr), clientChainAddrLength)
 	}
@@ -138,6 +142,7 @@ func (p Precompile) TokenFromInputs(ctx sdk.Context, args []interface{}) (types.
 	if !ok {
 		return types.AssetInfo{}, fmt.Errorf(exocmn.ErrContractInputParaOrType, 2, "uint8", args[2])
 	}
+	// #nosec G115
 	asset.Decimals = uint32(decimal)
 
 	tvlLimit, ok := args[3].(*big.Int)

--- a/precompiles/delegation/types.go
+++ b/precompiles/delegation/types.go
@@ -43,6 +43,7 @@ func (p Precompile) GetDelegationParamsFromInputs(ctx sdk.Context, args []interf
 	if !ok || assetAddr == nil {
 		return nil, fmt.Errorf(exocmn.ErrContractInputParaOrType, 2, "[]byte", args[2])
 	}
+	// #nosec G115
 	if uint32(len(assetAddr)) < clientChainAddrLength {
 		return nil, fmt.Errorf(exocmn.ErrInvalidAddrLength, len(assetAddr), clientChainAddrLength)
 	}
@@ -52,6 +53,7 @@ func (p Precompile) GetDelegationParamsFromInputs(ctx sdk.Context, args []interf
 	if !ok || stakerAddr == nil {
 		return nil, fmt.Errorf(exocmn.ErrContractInputParaOrType, 3, "[]byte", args[3])
 	}
+	// #nosec G115
 	if uint32(len(stakerAddr)) < clientChainAddrLength {
 		return nil, fmt.Errorf(exocmn.ErrInvalidAddrLength, len(stakerAddr), clientChainAddrLength)
 	}

--- a/precompiles/reward/parser.go
+++ b/precompiles/reward/parser.go
@@ -35,6 +35,7 @@ func (p Precompile) GetRewardParamsFromInputs(ctx sdk.Context, args []interface{
 	if !ok || assetAddr == nil {
 		return nil, fmt.Errorf(exocmn.ErrContractInputParaOrType, 1, "[]byte", assetAddr)
 	}
+	// #nosec G115
 	if uint32(len(assetAddr)) < clientChainAddrLength {
 		return nil, fmt.Errorf(exocmn.ErrInvalidAddrLength, len(assetAddr), clientChainAddrLength)
 	}
@@ -44,6 +45,7 @@ func (p Precompile) GetRewardParamsFromInputs(ctx sdk.Context, args []interface{
 	if !ok || stakerAddr == nil {
 		return nil, fmt.Errorf(exocmn.ErrContractInputParaOrType, 2, "[]byte", stakerAddr)
 	}
+	// #nosec G115
 	if uint32(len(stakerAddr)) < clientChainAddrLength {
 		return nil, fmt.Errorf(exocmn.ErrInvalidAddrLength, len(stakerAddr), clientChainAddrLength)
 	}

--- a/precompiles/slash/parser.go
+++ b/precompiles/slash/parser.go
@@ -34,6 +34,7 @@ func (p Precompile) GetSlashParamsFromInputs(ctx sdk.Context, args []interface{}
 	if !ok || assetAddr == nil {
 		return nil, fmt.Errorf(exocmn.ErrContractInputParaOrType, 1, "[]byte", assetAddr)
 	}
+	// #nosec G115
 	if uint32(len(assetAddr)) < clientChainAddrLength {
 		return nil, fmt.Errorf(exocmn.ErrInvalidAddrLength, len(assetAddr), clientChainAddrLength)
 	}
@@ -43,6 +44,7 @@ func (p Precompile) GetSlashParamsFromInputs(ctx sdk.Context, args []interface{}
 	if !ok || stakerAddr == nil {
 		return nil, fmt.Errorf(exocmn.ErrContractInputParaOrType, 2, "[]byte", stakerAddr)
 	}
+	// #nosec G115
 	if uint32(len(stakerAddr)) < clientChainAddrLength {
 		return nil, fmt.Errorf(exocmn.ErrInvalidAddrLength, len(stakerAddr), clientChainAddrLength)
 	}

--- a/testutil/nullify/nullify.go
+++ b/testutil/nullify/nullify.go
@@ -22,6 +22,7 @@ func Fill(x interface{}) interface{} {
 	case reflect.Slice:
 		for i := 0; i < v.Len(); i++ {
 			obj := v.Index(i)
+			// #nosec G115
 			objPt := reflect.NewAt(obj.Type(), unsafe.Pointer(obj.UnsafeAddr())).Interface()
 			objPt = Fill(objPt)
 			obj.Set(reflect.ValueOf(objPt))
@@ -46,6 +47,7 @@ func Fill(x interface{}) interface{} {
 					s := reflect.ValueOf(coins).Elem()
 					f.Set(s)
 				default:
+					// #nosec G115
 					objPt := reflect.NewAt(f.Type(), unsafe.Pointer(f.UnsafeAddr())).Interface()
 					s := Fill(objPt)
 					f.Set(reflect.ValueOf(s))

--- a/testutil/tx/cosmos.go
+++ b/testutil/tx/cosmos.go
@@ -53,7 +53,7 @@ func PrepareCosmosTx(
 
 	var fees sdk.Coins
 	if args.GasPrice != nil {
-		fees = sdk.Coins{{Denom: utils.BaseDenom, Amount: args.GasPrice.MulRaw(int64(args.Gas))}}
+		fees = sdk.Coins{{Denom: utils.BaseDenom, Amount: args.GasPrice.MulRaw(int64(args.Gas))}} // #nosec G115
 	} else {
 		fees = sdk.Coins{DefaultFee}
 	}

--- a/types/int.go
+++ b/types/int.go
@@ -17,8 +17,8 @@ func SafeInt64(value uint64) (int64, error) {
 	if value > uint64(math.MaxInt64) {
 		return 0, errorsmod.Wrapf(errortypes.ErrInvalidHeight, "uint64 value %v cannot exceed %v", value, int64(math.MaxInt64))
 	}
-
-	return int64(value), nil // #nosec G701 -- checked for int overflow already
+	// #nosec G115
+	return int64(value), nil
 }
 
 // SafeNewIntFromBigInt constructs Int from big.Int, return error if more than 256bits

--- a/x/assets/keeper/client_chain.go
+++ b/x/assets/keeper/client_chain.go
@@ -74,7 +74,7 @@ func (k Keeper) GetAllClientChainInfo(ctx sdk.Context) (infos []assetstype.Clien
 func (k Keeper) GetAllClientChainID(ctx sdk.Context) ([]uint32, error) {
 	ret := make([]uint32, 0)
 	opFunc := func(clientChain *assetstype.ClientChainInfo) error {
-		// #nosec G701 // already checked
+		// #nosec G115
 		ret = append(ret, uint32(clientChain.LayerZeroChainID))
 		return nil
 	}

--- a/x/avs/keeper/avs.go
+++ b/x/avs/keeper/avs.go
@@ -56,7 +56,7 @@ func (k *Keeper) GetAVSMinimumSelfDelegation(ctx sdk.Context, avsAddr string) (s
 	if err != nil {
 		return sdkmath.LegacyNewDec(0), errorsmod.Wrap(err, fmt.Sprintf("GetAVSMinimumSelfDelegation: key is %s", avsAddr))
 	}
-
+	// #nosec G115
 	return sdkmath.LegacyNewDec(int64(avsInfo.Info.MinSelfDelegation)), nil
 }
 
@@ -69,6 +69,7 @@ func (k *Keeper) GetEpochEndAVSs(ctx sdk.Context, epochIdentifier string, ending
 		// the currentEpoch is 1, so we will return it.
 		// consider another AVS which will start at epoch 5. the current epoch is 4.
 		// it should be returned here, since the operator module should start tracking this.
+		// #nosec G115
 		if epochIdentifier == avsInfo.EpochIdentifier && endingEpochNumber >= int64(avsInfo.StartingEpoch)-1 {
 			avsList = append(avsList, avsInfo.AvsAddress)
 		}
@@ -96,6 +97,7 @@ func (k *Keeper) GetTaskChallengeEpochEndAVSs(ctx sdk.Context, epochIdentifier s
 	k.IterateTaskAVSInfo(ctx, func(_ int64, taskInfo types.TaskInfo) (stop bool) {
 		avsInfo := k.GetAVSInfoByTaskAddress(ctx, taskInfo.TaskContractAddress)
 		// Determine if the challenge period has passed, the range of the challenge period is the num marked (StartingEpoch) add TaskChallengePeriod
+		// #nosec G115
 		if epochIdentifier == avsInfo.EpochIdentifier && epochNumber > int64(taskInfo.TaskChallengePeriod)+int64(taskInfo.StartingEpoch) {
 			taskList = append(taskList, taskInfo)
 		}

--- a/x/avs/keeper/keeper.go
+++ b/x/avs/keeper/keeper.go
@@ -94,8 +94,8 @@ func (k Keeper) AVSInfoUpdate(ctx sdk.Context, params *types.AVSRegisterOrDeregi
 			TaskAddr:            params.TaskAddr,
 			MinStakeAmount:      params.MinStakeAmount, // Effective at CurrentEpoch+1, avoid immediate effects and ensure that the first epoch time of avs is equal to a normal identifier
 			MinTotalStakeAmount: params.MinTotalStakeAmount,
-			AvsSlash:            sdk.NewDecWithPrec(int64(params.AvsSlash), 2),
-			AvsReward:           sdk.NewDecWithPrec(int64(params.AvsReward), 2),
+			AvsSlash:            sdk.NewDecWithPrec(int64(params.AvsSlash), 2),  // #nosec G115
+			AvsReward:           sdk.NewDecWithPrec(int64(params.AvsReward), 2), // #nosec G115
 		}
 
 		return k.SetAVSInfo(ctx, avs)
@@ -109,6 +109,7 @@ func (k Keeper) AVSInfoUpdate(ctx sdk.Context, params *types.AVSRegisterOrDeregi
 		}
 
 		// If avs DeRegisterAction check UnbondingPeriod
+		// #nosec G115
 		if epoch.CurrentEpoch-int64(avsInfo.GetInfo().StartingEpoch) > int64(avsInfo.Info.AvsUnbondingPeriod) {
 			return errorsmod.Wrap(types.ErrUnbondingPeriod, fmt.Sprintf("not qualified to deregister %s", avsInfo))
 		}
@@ -123,6 +124,7 @@ func (k Keeper) AVSInfoUpdate(ctx sdk.Context, params *types.AVSRegisterOrDeregi
 			return errorsmod.Wrap(types.ErrUnregisterNonExistent, fmt.Sprintf("the avsaddress is :%s", params.AvsAddress))
 		}
 		// If avs UpdateAction check UnbondingPeriod
+		// #nosec G115
 		if int64(avsInfo.Info.AvsUnbondingPeriod) < (epoch.CurrentEpoch - int64(avsInfo.GetInfo().StartingEpoch)) {
 			return errorsmod.Wrap(types.ErrUnbondingPeriod, fmt.Sprintf("not qualified to deregister %s", avsInfo))
 		}
@@ -171,10 +173,10 @@ func (k Keeper) AVSInfoUpdate(ctx sdk.Context, params *types.AVSRegisterOrDeregi
 			avs.MinTotalStakeAmount = params.MinTotalStakeAmount
 		}
 		if params.AvsSlash > 0 {
-			avs.AvsSlash = sdk.NewDecWithPrec(int64(params.AvsSlash), 2)
+			avs.AvsSlash = sdk.NewDecWithPrec(int64(params.AvsSlash), 2) // #nosec G115
 		}
 		if params.AvsReward > 0 {
-			avs.AvsReward = sdk.NewDecWithPrec(int64(params.AvsReward), 2)
+			avs.AvsReward = sdk.NewDecWithPrec(int64(params.AvsReward), 2) // #nosec G115
 		}
 		avs.AvsAddress = params.AvsAddress
 		avs.StartingEpoch = uint64(epoch.CurrentEpoch + 1)

--- a/x/dogfood/keeper/opt_out.go
+++ b/x/dogfood/keeper/opt_out.go
@@ -118,7 +118,7 @@ func (k Keeper) GetOperatorOptOutFinishEpoch(
 	}
 	// max int64 is 9 quintillion, and max uint64 is double of that.
 	// it is too far in the future to be a concern.
-	return int64(sdk.BigEndianToUint64(bz)) // #nosec G701 // see above.
+	return int64(sdk.BigEndianToUint64(bz)) // #nosec G115
 }
 
 // DeleteOperatorOptOutFinishEpoch deletes the epoch at which an operator's opt out will be

--- a/x/dogfood/types/keys.go
+++ b/x/dogfood/types/keys.go
@@ -170,7 +170,7 @@ func SafeUint64ToInt64(id uint64) (int64, bool) {
 	if id > math.MaxInt64 {
 		return 0, false
 	}
-	return int64(id), true // #nosec G701 // already checked.
+	return int64(id), true // #nosec G115 // already checked.
 }
 
 // HistoricalInfoKey returns the key to historical info to a given block height

--- a/x/evm/keeper/grpc_query.go
+++ b/x/evm/keeper/grpc_query.go
@@ -595,8 +595,9 @@ func (k *Keeper) traceTx(
 
 	tCtx := &tracers.Context{
 		BlockHash: txConfig.BlockHash,
-		TxIndex:   int(txConfig.TxIndex),
-		TxHash:    txConfig.TxHash,
+		// #nosec G115
+		TxIndex: int(txConfig.TxIndex),
+		TxHash:  txConfig.TxHash,
 	}
 
 	if traceConfig.Tracer != "" {

--- a/x/evm/keeper/msg_server.go
+++ b/x/evm/keeper/msg_server.go
@@ -62,8 +62,8 @@ func (k *Keeper) EthereumTx(goCtx context.Context, msg *types.MsgEthereumTx) (*t
 
 			// Observe which users define a gas limit >> gas used. Note, that
 			// gas_limit and gas_used are always > 0
-			gasLimit := sdk.NewDec(int64(tx.Gas()))
-			gasRatio, err := gasLimit.QuoInt64(int64(response.GasUsed)).Float64()
+			gasLimit := sdk.NewDec(int64(tx.Gas()))                               // #nosec G115
+			gasRatio, err := gasLimit.QuoInt64(int64(response.GasUsed)).Float64() // #nosec G115
 			if err == nil {
 				telemetry.SetGaugeWithLabels(
 					[]string{"tx", "msg", "ethereum_tx", "gas_limit", "per", "gas_used"},

--- a/x/evm/keeper/state_transition.go
+++ b/x/evm/keeper/state_transition.go
@@ -412,7 +412,7 @@ func (k *Keeper) ApplyMessageWithConfig(ctx sdk.Context,
 	// calculate a minimum amount of gas to be charged to sender if GasLimit
 	// is considerably higher than GasUsed to stay more aligned with Tendermint gas mechanics
 	// for more info https://github.com/evmos/ethermint/issues/1085
-	gasLimit := sdk.NewDec(int64(msg.Gas()))
+	gasLimit := sdk.NewDec(int64(msg.Gas())) // #nosec G115
 	minGasMultiplier := k.GetMinGasMultiplier(ctx)
 	minimumGasUsed := gasLimit.Mul(minGasMultiplier)
 
@@ -423,7 +423,7 @@ func (k *Keeper) ApplyMessageWithConfig(ctx sdk.Context,
 	if msg.Gas() < leftoverGas {
 		return nil, errorsmod.Wrapf(types.ErrGasOverflow, "message gas limit < leftover gas (%d < %d)", msg.Gas(), leftoverGas)
 	}
-
+	// #nosec G115
 	gasUsed := sdk.MaxDec(minimumGasUsed, sdk.NewDec(int64(temporaryGasUsed))).TruncateInt().Uint64()
 	// reset leftoverGas, to be used by the tracer
 	leftoverGas = msg.Gas() - gasUsed

--- a/x/operator/keeper/common_func.go
+++ b/x/operator/keeper/common_func.go
@@ -8,7 +8,7 @@ import (
 func CalculateUSDValue(assetAmount sdkmath.Int, price sdkmath.Int, assetDecimal uint32, priceDecimal uint8) sdkmath.LegacyDec {
 	assetValue := assetAmount.Mul(price)
 	assetValueDec := sdkmath.LegacyNewDecFromBigInt(assetValue.BigInt())
-	// #nosec G701
+	// #nosec G115
 	divisor := sdkmath.NewIntWithDecimal(1, int(assetDecimal)+int(priceDecimal))
 	return assetValueDec.QuoInt(divisor)
 }

--- a/x/oracle/client/cli/tx_create_price.go
+++ b/x/oracle/client/cli/tx_create_price.go
@@ -60,7 +60,8 @@ func CmdCreatePrice() *cobra.Command {
 				argLength -= 3
 				i += 3
 				prices[0].Prices = append(prices[0].Prices, &types.PriceTimeDetID{
-					Price:     price,
+					Price: price,
+					// #nosec G115
 					Decimal:   int32(decimal),
 					Timestamp: timestamp,
 					DetID:     detID,
@@ -75,6 +76,7 @@ func CmdCreatePrice() *cobra.Command {
 				feederID,
 				prices,
 				basedBlock,
+				// #nosec G115
 				int32(nonce),
 			)
 			if err := msg.ValidateBasic(); err != nil {

--- a/x/oracle/keeper/aggregator/filter.go
+++ b/x/oracle/keeper/aggregator/filter.go
@@ -54,6 +54,7 @@ func (f *filter) addPSource(pSources []*types.PriceSource, validator string) (li
 	for _, pSource := range pSources {
 		// check conflicts or duplicate data for the same roundID within the same source
 		if len(pSource.Prices[0].DetID) > 0 {
+			// #nosec G115
 			k := validator + strconv.Itoa(int(pSource.SourceID))
 			detIDs := f.validatorSource[k]
 			if detIDs == nil {

--- a/x/oracle/keeper/prices.go
+++ b/x/oracle/keeper/prices.go
@@ -74,7 +74,7 @@ func (k Keeper) GetSpecifiedAssetsPrice(ctx sdk.Context, assetID string) (types.
 	}
 	return types.Price{
 		Value:   v,
-		Decimal: uint8(price.Decimal),
+		Decimal: uint8(price.Decimal), // #nosec G115
 	}, nil
 }
 
@@ -117,7 +117,7 @@ func (k Keeper) GetMultipleAssetsPrices(ctx sdk.Context, assets map[string]inter
 			}
 			prices[assetID] = types.Price{
 				Value:   v,
-				Decimal: uint8(price.Decimal),
+				Decimal: uint8(price.Decimal), // #nosec G115
 			}
 		}
 	}

--- a/x/oracle/keeper/recent_msg.go
+++ b/x/oracle/keeper/recent_msg.go
@@ -71,6 +71,7 @@ func (k Keeper) GetAllRecentMsgAsMap(ctx sdk.Context) (result map[int64][]*types
 		var val types.RecentMsg
 		k.cdc.MustUnmarshal(iterator.Value(), &val)
 		//		list = append(list, val)
+		// #nosec G115
 		result[int64(val.Block)] = val.Msgs
 	}
 

--- a/x/oracle/keeper/recent_params.go
+++ b/x/oracle/keeper/recent_params.go
@@ -71,6 +71,7 @@ func (k Keeper) GetAllRecentParamsAsMap(ctx sdk.Context) (result map[int64]*type
 	for ; iterator.Valid(); iterator.Next() {
 		var val types.RecentParams
 		k.cdc.MustUnmarshal(iterator.Value(), &val)
+		// #nosec G115
 		result[int64(val.Block)] = val.Params
 	}
 

--- a/x/oracle/keeper/single.go
+++ b/x/oracle/keeper/single.go
@@ -74,7 +74,7 @@ func recacheAggregatorContext(ctx sdk.Context, agc *aggregator.AggregatorContext
 		// no cache, this is the very first running, so go to initial process instead
 		return false
 	}
-
+	// #nosec G115
 	if int64(h.Block) >= from {
 		from = int64(h.Block) + 1
 	}


### PR DESCRIPTION
## Description

This PR temporarily ignores the `gosec G115` warning. In the future, the types of related fields might be changed, and this ignore should be reconsidered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
	- Updated comments to suppress specific security warnings across various functions, enhancing documentation regarding security practices without altering functionality.
	- Adjusted comment identifiers from `G701` to `G115` in multiple locations to reflect a reassessment of security implications while maintaining the core logic intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->