### PR TITLE
fix(ci): pin the golang lint version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,8 +37,7 @@ jobs:
       # Now, the actual golangci-lint configuration
       - uses: golangci/golangci-lint-action@v4
         with:
-          # Required parameter
-          version: latest
+          version: "v1.59.1"
           args: --timeout 10m
           github-token: ${{ secrets.github_token }}
         # Check only if there are differences in the source code


### PR DESCRIPTION
There are some major changes in `1.60.3`, the current `latest` version which break our CI. To avoid them, we pin the version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the linting configuration to use a fixed version of the `golangci-lint` tool, enhancing consistency and reliability in linting results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->