### PR TITLE
fix(unjail): fix the issue regarding unjail failed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ WORKDIR /root
 COPY --from=build-env /go/src/github.com/ExocoreNetwork/exocore/build/exocored /usr/bin/exocored
 COPY --from=build-env /go/bin/toml-cli /usr/bin/toml-cli
 
-RUN apk add --no-cache ca-certificates=20240226-r0 libstdc++=13.2.1_git20231014-r0 jq=1.7.1-r0 curl=8.9.0-r0 bash=5.2.21-r0 vim=9.0.2127-r0 lz4=1.9.4-r5 rclone=1.65.0-r3 \
+RUN apk add --no-cache ca-certificates=20240226-r0 libstdc++=13.2.1_git20231014-r0 jq=1.7.1-r0 curl=8.9.1-r0 bash=5.2.21-r0 vim=9.0.2127-r0 lz4=1.9.4-r5 rclone=1.65.0-r3 \
     && addgroup -g 1000 exocore \
     && adduser -S -h /home/exocore -D exocore -u 1000 -G exocore
 

--- a/networks/local/exocore/Dockerfile
+++ b/networks/local/exocore/Dockerfile
@@ -10,7 +10,7 @@ RUN LEDGER_ENABLED=false make build
 
 #####################################
 FROM alpine:3.19 AS run
-RUN apk add --no-cache libstdc++=13.2.1_git20231014-r0 bash=5.2.21-r0 curl=8.9.0-r0 jq=1.7.1-r0 \
+RUN apk add --no-cache libstdc++=13.2.1_git20231014-r0 bash=5.2.21-r0 curl=8.9.1-r0 jq=1.7.1-r0 \
     && addgroup -g 1000 exocore \
     && adduser -S -h /home/exocore -D exocore -u 1000 -G exocore
 EXPOSE 26656 26657 1317 9090 8545 8546

--- a/x/dogfood/keeper/impl_sdk.go
+++ b/x/dogfood/keeper/impl_sdk.go
@@ -146,7 +146,7 @@ func (k Keeper) Delegation(
 	// This interface is only used for unjail to retrieve the self delegation value,
 	// so the delegator and validator are the same.
 	operator := delegator
-	operatorUSDValues, err := k.operatorKeeper.GetOrCalculateOperatorUSDValues(ctx, operator, ctx.ChainID())
+	operatorUSDValues, err := k.operatorKeeper.GetOrCalculateOperatorUSDValues(ctx, operator, avstypes.ChainIDWithoutRevision(ctx.ChainID()))
 	if err != nil {
 		k.Logger(ctx).Error("Delegation: failed to get or calculate the operator USD values", "operator", operator.String(), "chainID", ctx.ChainID(), "error", err)
 		return nil

--- a/x/operator/keeper/usd_value.go
+++ b/x/operator/keeper/usd_value.go
@@ -229,11 +229,11 @@ func (k *Keeper) IterateOperatorsForAVS(ctx sdk.Context, avsAddr string, isUpdat
 }
 
 func (k Keeper) GetVotePowerForChainID(
-	ctx sdk.Context, operators []sdk.AccAddress, chainID string,
+	ctx sdk.Context, operators []sdk.AccAddress, chainIDWithoutRevision string,
 ) ([]int64, error) {
-	isAvs, avsAddr := k.avsKeeper.IsAVSByChainID(ctx, chainID)
+	isAvs, avsAddr := k.avsKeeper.IsAVSByChainID(ctx, chainIDWithoutRevision)
 	if !isAvs {
-		return nil, errorsmod.Wrap(operatortypes.ErrUnknownChainID, fmt.Sprintf("GetVotePowerForChainID: chainID is %s", chainID))
+		return nil, errorsmod.Wrap(operatortypes.ErrUnknownChainID, fmt.Sprintf("GetVotePowerForChainID: chainIDWithoutRevision is %s", chainIDWithoutRevision))
 	}
 	ret := make([]int64, 0)
 	avsAddrString := avsAddr.String()
@@ -250,10 +250,10 @@ func (k Keeper) GetVotePowerForChainID(
 	return ret, nil
 }
 
-func (k *Keeper) GetOperatorAssetValue(ctx sdk.Context, operator sdk.AccAddress, chainID string) (int64, error) {
-	isAvs, avsAddr := k.avsKeeper.IsAVSByChainID(ctx, chainID)
+func (k *Keeper) GetOperatorAssetValue(ctx sdk.Context, operator sdk.AccAddress, chainIDWithoutRevision string) (int64, error) {
+	isAvs, avsAddr := k.avsKeeper.IsAVSByChainID(ctx, chainIDWithoutRevision)
 	if !isAvs {
-		return 0, errorsmod.Wrap(operatortypes.ErrUnknownChainID, fmt.Sprintf("GetOperatorAssetValue: chainID is %s", chainID))
+		return 0, errorsmod.Wrap(operatortypes.ErrUnknownChainID, fmt.Sprintf("GetOperatorAssetValue: chainIDWithoutRevision is %s", chainIDWithoutRevision))
 	}
 	optedUSDValues, err := k.GetOperatorOptedUSDValue(ctx, operator.String(), avsAddr.String())
 	if err != nil {
@@ -345,11 +345,11 @@ func (k *Keeper) CalculateUSDValueForOperator(
 func (k Keeper) GetOrCalculateOperatorUSDValues(
 	ctx sdk.Context,
 	operator sdk.AccAddress,
-	chainID string,
+	chainIDWithoutRevision string,
 ) (optedUSDValues operatortypes.OperatorOptedUSDValue, err error) {
-	isAvs, avsAddr := k.avsKeeper.IsAVSByChainID(ctx, chainID)
+	isAvs, avsAddr := k.avsKeeper.IsAVSByChainID(ctx, chainIDWithoutRevision)
 	if !isAvs {
-		return operatortypes.OperatorOptedUSDValue{}, errorsmod.Wrap(operatortypes.ErrUnknownChainID, fmt.Sprintf("GetOrCalculateOperatorUSDValues: chainID is %s", chainID))
+		return operatortypes.OperatorOptedUSDValue{}, errorsmod.Wrap(operatortypes.ErrUnknownChainID, fmt.Sprintf("GetOrCalculateOperatorUSDValues: chainIDWithoutRevision is %s", chainIDWithoutRevision))
 	}
 	avsAddrString := avsAddr.String()
 	// the usd values will be deleted if the operator opts out, so recalculate the


### PR DESCRIPTION
## Description

The unjail operation will fail because the input chainID isn't ChainIDWithoutRevision, which results in an incorrect dogfood AVS address being generated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Improved clarity in function parameters related to chain ID processing by renaming to reflect the exclusion of revision information.
  
- **Bug Fixes**
	- Enhanced error messaging for unknown chain IDs to provide clearer feedback.

- **Chores**
	- Updated the `curl` package version in Dockerfiles to ensure the use of a more recent version, potentially introducing bug fixes or new features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->