### PR TITLE
refactor: change base denom to `hua`

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -28,7 +28,7 @@ const (
 	// DisplayDenom defines the denomination displayed to users in client applications.
 	DisplayDenom = "exo"
 	// BaseDenom defines to the default denomination used in Evmos (EVM, governance, etc.)
-	BaseDenom = "aexo"
+	BaseDenom = "hua"
 )
 
 // SetBech32Prefixes sets the global prefixes to be used when serializing addresses and public keys to Bech32 strings.

--- a/init.bat
+++ b/init.bat
@@ -39,11 +39,11 @@ exocored keys add %KEY% --keyring-backend %KEYRING% --algo %ALGO%
 rem Set moniker and chain-id for exocore (Moniker can be anything, chain-id must be an integer)
 exocored init %MONIKER% --chain-id %CHAINID% 
 
-rem Change parameter token denominations to aexocore
-cat %GENESIS% | jq ".app_state[\"staking\"][\"params\"][\"bond_denom\"]=\"aexocore\""   >   %TMPGENESIS% && move %TMPGENESIS% %GENESIS%
-cat %GENESIS% | jq ".app_state[\"crisis\"][\"constant_fee\"][\"denom\"]=\"aexocore\"" > %TMPGENESIS% && move %TMPGENESIS% %GENESIS%
-cat %GENESIS% | jq ".app_state[\"gov\"][\"deposit_params\"][\"min_deposit\"][0][\"denom\"]=\"aexocore\"" > %TMPGENESIS% && move %TMPGENESIS% %GENESIS%
-cat %GENESIS% | jq ".app_state[\"mint\"][\"params\"][\"mint_denom\"]=\"aexocore\"" > %TMPGENESIS% && move %TMPGENESIS% %GENESIS%
+rem Change parameter token denominations to hua
+cat %GENESIS% | jq ".app_state[\"staking\"][\"params\"][\"bond_denom\"]=\"hua\""   >   %TMPGENESIS% && move %TMPGENESIS% %GENESIS%
+cat %GENESIS% | jq ".app_state[\"crisis\"][\"constant_fee\"][\"denom\"]=\"hua\"" > %TMPGENESIS% && move %TMPGENESIS% %GENESIS%
+cat %GENESIS% | jq ".app_state[\"gov\"][\"deposit_params\"][\"min_deposit\"][0][\"denom\"]=\"hua\"" > %TMPGENESIS% && move %TMPGENESIS% %GENESIS%
+cat %GENESIS% | jq ".app_state[\"mint\"][\"params\"][\"mint_denom\"]=\"hua\"" > %TMPGENESIS% && move %TMPGENESIS% %GENESIS%
 
 rem increase block time (?)
 cat %GENESIS% | jq ".consensus_params[\"block\"][\"time_iota_ms\"]=\"30000\"" > %TMPGENESIS% && move %TMPGENESIS% %GENESIS%
@@ -55,10 +55,10 @@ rem setup
 sed -i "s/create_empty_blocks = true/create_empty_blocks = false/g" %ETHCONFIG%
 
 rem Allocate genesis accounts (cosmos formatted addresses)
-exocored add-genesis-account %KEY% 100000000000000000000000000aexocore --keyring-backend %KEYRING%
+exocored add-genesis-account %KEY% 100000000000000000000000000hua --keyring-backend %KEYRING%
 
 rem Sign genesis transaction
-exocored gentx %KEY% 1000000000000000000000aexocore --keyring-backend %KEYRING% --chain-id %CHAINID%
+exocored gentx %KEY% 1000000000000000000000hua --keyring-backend %KEYRING% --chain-id %CHAINID%
 
 rem Collect genesis tx
 exocored collect-gentxs
@@ -69,4 +69,4 @@ exocored validate-genesis
 
 
 rem Start the node (remove the --pruning=nothing flag if historical queries are not needed)
-exocored start --pruning=nothing %TRACE% --log_level %LOGLEVEL% --minimum-gas-prices=0.0001aexocore
+exocored start --pruning=nothing %TRACE% --log_level %LOGLEVEL% --minimum-gas-prices=0.0001hua

--- a/local_node.sh
+++ b/local_node.sh
@@ -87,12 +87,12 @@ if [[ $overwrite == "y" || $overwrite == "Y" ]]; then
 	LOCAL_ADDRESS_HEX=0x$(exocored keys parse "$LOCAL_ADDRESS_EXO" --output json | jq -r .bytes | tr '[:upper:]' '[:lower:]')
 	CONSENSUS_KEY=$(exocored keys consensus-pubkey-to-bytes --keyring-backend "$KEYRING" --home "$HOMEDIR" --output json | jq -r .bytes32)
 
-	# Change parameter token denominations to aexo
-	jq '.app_state["crisis"]["constant_fee"]["denom"]="aexo"' "$GENESIS" >"$TMP_GENESIS" && mv "$TMP_GENESIS" "$GENESIS"
-	jq '.app_state["gov"]["deposit_params"]["min_deposit"][0]["denom"]="aexo"' "$GENESIS" >"$TMP_GENESIS" && mv "$TMP_GENESIS" "$GENESIS"
+	# Change parameter token denominations to hua
+	jq '.app_state["crisis"]["constant_fee"]["denom"]="hua"' "$GENESIS" >"$TMP_GENESIS" && mv "$TMP_GENESIS" "$GENESIS"
+	jq '.app_state["gov"]["deposit_params"]["min_deposit"][0]["denom"]="hua"' "$GENESIS" >"$TMP_GENESIS" && mv "$TMP_GENESIS" "$GENESIS"
 	# When upgrade to cosmos-sdk v0.47, use gov.params to edit the deposit params
-	jq '.app_state["gov"]["params"]["min_deposit"][0]["denom"]="aexo"' "$GENESIS" >"$TMP_GENESIS" && mv "$TMP_GENESIS" "$GENESIS"
-	jq '.app_state["evm"]["params"]["evm_denom"]="aexo"' "$GENESIS" >"$TMP_GENESIS" && mv "$TMP_GENESIS" "$GENESIS"
+	jq '.app_state["gov"]["params"]["min_deposit"][0]["denom"]="hua"' "$GENESIS" >"$TMP_GENESIS" && mv "$TMP_GENESIS" "$GENESIS"
+	jq '.app_state["evm"]["params"]["evm_denom"]="hua"' "$GENESIS" >"$TMP_GENESIS" && mv "$TMP_GENESIS" "$GENESIS"
 
 	# Set gas limit in genesis
 	jq '.consensus_params["block"]["max_gas"]="10000000"' "$GENESIS" >"$TMP_GENESIS" && mv "$TMP_GENESIS" "$GENESIS"
@@ -275,9 +275,9 @@ EOF
 
 	# Allocate genesis accounts (cosmos formatted addresses)
 	for KEY in "${KEYS[@]}"; do
-		exocored add-genesis-account "$KEY" 100000000000000000000000000aexo --keyring-backend "$KEYRING" --home "$HOMEDIR"
+		exocored add-genesis-account "$KEY" 100000000000000000000000000hua --keyring-backend "$KEYRING" --home "$HOMEDIR"
 	done
-	exocored add-genesis-account "${LOCAL_NAME}" 100000000000000000000000000aexo --keyring-backend "$KEYRING" --home "$HOMEDIR"
+	exocored add-genesis-account "${LOCAL_NAME}" 100000000000000000000000000hua --keyring-backend "$KEYRING" --home "$HOMEDIR"
 
 	# bc is required to add these big numbers
 	# note the extra +1 is for LOCAL_NAME
@@ -293,4 +293,4 @@ EOF
 fi
 
 # Start the node (remove the --pruning=nothing flag if historical queries are not needed)
-exocored start --metrics "$TRACE" --log_level $LOGLEVEL --minimum-gas-prices=0.0001aexo --json-rpc.api eth,txpool,personal,net,debug,web3 --api.enable --json-rpc.enable true --home "$HOMEDIR" --chain-id "$CHAINID" --oracle --grpc.enable true
+exocored start --metrics "$TRACE" --log_level $LOGLEVEL --minimum-gas-prices=0.0001hua --json-rpc.api eth,txpool,personal,net,debug,web3 --api.enable --json-rpc.enable true --home "$HOMEDIR" --chain-id "$CHAINID" --oracle --grpc.enable true

--- a/networks/local/exocore/Dockerfile
+++ b/networks/local/exocore/Dockerfile
@@ -15,7 +15,7 @@ RUN apk add --no-cache libstdc++=13.2.1_git20231014-r0 bash=5.2.21-r0 curl=8.9.1
     && adduser -S -h /home/exocore -D exocore -u 1000 -G exocore
 EXPOSE 26656 26657 1317 9090 8545 8546
 # TODO: exocore testnet chainid is still under consideration and need to be finalized later
-CMD ["start", "--log_format", "plain", "--chain-id", "exocoretestnet_233-1", "--metrics", "--json-rpc.api", "eth,txpool,personal,net,debug,web3", "--api.enable", "--json-rpc.enable", "true", "--minimum-gas-prices", "0.0001aexocore"]
+CMD ["start", "--log_format", "plain", "--chain-id", "exocoretestnet_233-1", "--metrics", "--json-rpc.api", "eth,txpool,personal,net,debug,web3", "--api.enable", "--json-rpc.enable", "true", "--minimum-gas-prices", "0.0001hua"]
 # by default, a SIGKILL is sent after 10 seconds. We need to override this to allow graceful shutdown.
 STOPSIGNAL SIGTERM
 VOLUME /exocore

--- a/testutil/contract.go
+++ b/testutil/contract.go
@@ -39,7 +39,7 @@ type ContractCallArgs struct {
 	Contract ContractArgs
 	// Nonce is the nonce to use for the transaction.
 	Nonce *big.Int
-	// Amount is the aexo amount to send in the transaction.
+	// Amount is the hua amount to send in the transaction.
 	Amount *big.Int
 	// GasLimit to use for the transaction
 	GasLimit uint64

--- a/testutil/network/network.go
+++ b/testutil/network/network.go
@@ -111,7 +111,7 @@ func DefaultConfig() Config {
 		TimeoutCommit:     3 * time.Second,
 		ChainID:           chainID,
 		NumValidators:     4,
-		BondDenom:         "aexo",
+		BondDenom:         "hua",
 		MinGasPrices:      fmt.Sprintf("0.000006%s", evmostypes.AttoEvmos),
 		AccountTokens:     sdk.TokensFromConsensusPower(1000000000000000000, evmostypes.PowerReduction),
 		StakingTokens:     sdk.TokensFromConsensusPower(500000000000000000, evmostypes.PowerReduction),

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -24,7 +24,7 @@ const (
 	// DefaultChainID is the standard chain id used for testing purposes
 	DefaultChainID = MainnetChainID + "-1"
 	// BaseDenom defines the Evmos mainnet denomination
-	BaseDenom = "aexo"
+	BaseDenom = "hua"
 
 	// DelimiterForCombinedKey is the delimiter used for constructing the combined key.
 	DelimiterForCombinedKey = "/"

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -81,7 +81,7 @@ func TestExocoreCoinDenom(t *testing.T) {
 	}{
 		{
 			"valid denom - native coin",
-			"aexo",
+			"hua",
 			false,
 		},
 		{


### PR DESCRIPTION
The names `aexo` and `exo` make it a bit confusing for readers. Instead, we rename the smaller token to `hua` and the bigger token to `exo` such that 1 exo = 1e18 hua.

Verified that `bank send` can be used to send `exo` and `hua` with the balance reflected in `hua` even if `exo` is sent. The factor of `1e18` is correctly applied.