### PR TITLE
fix(assets): allow native chain to be registered

### DIFF
--- a/precompiles/assets/tx.go
+++ b/precompiles/assets/tx.go
@@ -216,6 +216,10 @@ func (p Precompile) IsRegisteredClientChain(
 	if err != nil {
 		return nil, err
 	}
+	if clientChainID == 0 {
+		// explicitly return false for client chain ID 0 to prevent `setPeer` calls
+		return method.Outputs.Pack(true, false)
+	}
 	exists := p.assetsKeeper.ClientChainExists(ctx, uint64(clientChainID))
 	return method.Outputs.Pack(true, exists)
 }

--- a/x/assets/types/genesis.go
+++ b/x/assets/types/genesis.go
@@ -45,14 +45,6 @@ func (gs GenesisState) ValidateClientChains() (map[uint64]struct{}, error) {
 				i,
 			)
 		}
-		// this is our primary method of cross-chain communication.
-		if info.LayerZeroChainID == 0 {
-			return errorsmod.Wrapf(
-				ErrInvalidGenesisData,
-				"nil LayerZeroChainID for chain %s",
-				info.Name,
-			)
-		}
 		// the address length is used to convert from bytes32 to address.
 		if info.AddressLength == 0 {
 			return errorsmod.Wrapf(

--- a/x/assets/types/genesis_test.go
+++ b/x/assets/types/genesis_test.go
@@ -106,22 +106,6 @@ func (suite *GenesisTestSuite) TestValidateGenesis() {
 			expPass: false,
 		},
 		{
-			name: "invalid genesis due to zero layer zero chain id",
-			genState: &types.GenesisState{
-				Params: types.DefaultParams(),
-				ClientChains: []types.ClientChainInfo{
-					ethClientChain,
-				},
-			},
-			malleate: func(gs *types.GenesisState) {
-				gs.ClientChains[0].LayerZeroChainID = 0
-			},
-			unmalleate: func(gs *types.GenesisState) {
-				gs.ClientChains[0].LayerZeroChainID = 101
-			},
-			expPass: false,
-		},
-		{
 			name: "invalid genesis due to zero address length",
 			genState: &types.GenesisState{
 				Params: types.DefaultParams(),


### PR DESCRIPTION
- LayerZero ID of 0 supported for native chain
- `IsRegisteredClientChain` explicitly returns `false` to prevent cross-chain messaging
- Adding more native tokens or modifying the existing ones **is allowed**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a conditional check for unregistered client chains, enhancing error handling for clientChainID of 0.
  
- **Bug Fixes**
	- Removed outdated validation for LayerZeroChainID in the GenesisState, streamlining the client chain validation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->