### PR TITLE
fix: remove hardcoded seeds

### DIFF
--- a/cmd/exocored/init.go
+++ b/cmd/exocored/init.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -81,13 +80,7 @@ func InitCmd(mbm module.BasicManager, defaultNodeHome string) *cobra.Command {
 			config.P2P.MaxNumInboundPeers = 240
 			config.P2P.MaxNumOutboundPeers = 30
 
-			// Set default seeds
-			seeds := []string{
-				"40f4fac63da8b1ce8f850b0fa0f79b2699d2ce72@seed.evmos.jerrychong.com:26656",                 // jerrychong
-				"e3e11fca4ecf4035a751f3fea90e3a821e274487@bd-evmos-mainnet-seed-node-01.bdnodes.net:26656", // blockdaemon
-				"fc86e7e75c5d2e4699535e1b1bec98ae55b16826@bd-evmos-mainnet-seed-node-02.bdnodes.net:26656", // blockdaemon
-			}
-			config.P2P.Seeds = strings.Join(seeds, ",")
+			// if we decide to hardcode any seeds, they may be added here
 
 			config.Mempool.Size = 10000
 			config.StateSync.TrustPeriod = 112 * time.Hour

--- a/cmd/exocored/init.go
+++ b/cmd/exocored/init.go
@@ -80,7 +80,7 @@ func InitCmd(mbm module.BasicManager, defaultNodeHome string) *cobra.Command {
 			config.P2P.MaxNumInboundPeers = 240
 			config.P2P.MaxNumOutboundPeers = 30
 
-			// if we decide to hardcode any seeds, they may be added here
+			// TODO: hardcode any seeds here
 
 			config.Mempool.Size = 10000
 			config.StateSync.TrustPeriod = 112 * time.Hour


### PR DESCRIPTION
When running `exocored init`, our code supplies some hardcoded seeds. Since our installation guides suggest the configuration of the seeds manually, the hardcoded and outdated seeds may be removed.