### PR TITLE
convert UpdateBalance to use relative amount instead of absolute amount change

### DIFF
--- a/x/oracle/keeper/native_token_test.go
+++ b/x/oracle/keeper/native_token_test.go
@@ -138,7 +138,7 @@ func (ks *KeeperSuite) TestNSTLifeCycleOneStaker() {
 	// - 4.1 check stakerInfo
 	stakerInfo = ks.App.OracleKeeper.GetStakerInfo(ks.Ctx, assetID, stakerStr)
 	ks.Equal(types.BalanceInfo{
-		Balance: 59,
+		Balance: 49,
 		Block:   1,
 		RoundID: 11,
 		Index:   0,
@@ -146,10 +146,10 @@ func (ks *KeeperSuite) TestNSTLifeCycleOneStaker() {
 	}, *stakerInfo.BalanceList[3])
 	// check stakerAssetInfo is updated correctly in assets module, this should be triggered in assets module by oracle module's UpdateNSTByBalanceChange
 	stakerAssetInfo, _ = ks.App.AssetsKeeper.GetStakerSpecifiedAssetInfo(ks.Ctx, stakerID, assetID)
-	amount59 := sdkmath.NewIntWithDecimal(59, 18)
+	amount49 := sdkmath.NewIntWithDecimal(49, 18)
 	ks.Equal(assetstypes.StakerAssetInfo{
-		TotalDepositAmount:        amount59,
-		WithdrawableAmount:        amount59,
+		TotalDepositAmount:        amount49,
+		WithdrawableAmount:        amount49,
 		PendingUndelegationAmount: sdk.ZeroInt(),
 	}, *stakerAssetInfo)
 
@@ -159,7 +159,7 @@ func (ks *KeeperSuite) TestNSTLifeCycleOneStaker() {
 	// - 5.1 check stakerInfo
 	stakerInfo = ks.App.OracleKeeper.GetStakerInfo(ks.Ctx, assetID, stakerStr)
 	ks.Equal(types.BalanceInfo{
-		Balance: 29,
+		Balance: 19,
 		Block:   1,
 		RoundID: 11,
 		Index:   1,


### PR DESCRIPTION
## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Use relative balance change compared to previous amount, instead of absolute change compared to 32ETH as base.\

Pro: This will suites all assets, don't need to hard code NSTETH assetID

Cons: Introduce complexity of synchronization for price-feeder
- use hash to set event to indicate the exactly price update
- query onchain balance infos for alls takers every time before feed balancechange of NST

Conclusion: If there's no too many chains for NST-restaking senario, the existing ETH-specified version is prefered.

----

Closes #XXX

<!--
< < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

PR review checkboxes:

I have...

- [ ] added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] included the correct
      [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json)
      in the PR title
- [ ] targeted the correct branch
      (see [PR Targeting](https://github.com/ExocoreNetwork/exocore/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link in the PR description to the relevant issue or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all required CI checks have passed

Code maintenance:

I have...

- [ ] written unit and integration [tests](https://github.com/ExocoreNetwork/exocore/blob/main/CONTRIBUTING.md#testing)
- [ ] added relevant [`godoc`](https://go.dev/blog/godoc) and [code comments](https://blog.jbowen.dev/2019/09/the-magic-of-go-comments/).
- [ ] updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)

______

### Reviewers Checklist

**All** items are required.
Please add a note if the item is not applicable
and please add your handle next to the items reviewed
if you only reviewed selected items.

I have...

- [ ] confirmed the correct
      [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json)
      in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] confirmed that this PR does not change production code

-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced enhanced staker management for native-restaking assets, including methods for updating validator lists and retrieving total balance changes.
	- Added a mechanism to hash prices exceeding a specified length for improved data handling.

- **Bug Fixes**
	- Corrected balance calculations and assertions in tests to align with updated logic for staker operations.

- **Documentation**
	- Updated comments to clarify the purpose and functionality of new and modified methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->