### PR TITLE
refactor(assets): validator pubkey -> id

### DIFF
--- a/precompiles/assets/IAssets.sol
+++ b/precompiles/assets/IAssets.sol
@@ -36,12 +36,12 @@ interface IAssets {
     /// @param clientChainID is the layerZero chainID if it is supported.
     //  It might be allocated by Exocore when the client chain isn't supported
     //  by layerZero
-    /// @param validatorPubkey The validator's pubkey
+    /// @param validatorID The validator's identifier (index or pubkey)
     /// @param stakerAddress The staker address
     /// @param opAmount The amount to deposit
     function depositNST(
         uint32 clientChainID,
-        bytes calldata validatorPubkey,
+        bytes calldata validatorID,
         bytes calldata stakerAddress,
         uint256 opAmount
     ) external returns (bool success, uint256 latestAssetState);
@@ -66,12 +66,12 @@ interface IAssets {
     /// @param clientChainID is the layerZero chainID if it is supported.
     //  It might be allocated by Exocore when the client chain isn't supported
     //  by layerZero
-    /// @param validatorPubkey The validator's pubkey
+    /// @param validatorID The validator's identifier (index or pubkey)
     /// @param withdrawAddress The withdraw address
     /// @param opAmount The withdraw amount
     function withdrawNST(
         uint32 clientChainID,
-        bytes calldata validatorPubkey,
+        bytes calldata validatorID,
         bytes calldata withdrawAddress,
         uint256 opAmount
     ) external returns (bool success, uint256 latestAssetState);

--- a/precompiles/assets/abi.json
+++ b/precompiles/assets/abi.json
@@ -50,7 +50,7 @@
       },
       {
         "internalType": "bytes",
-        "name": "validatorPubkey",
+        "name": "validatorID",
         "type": "bytes"
       },
       {
@@ -300,7 +300,7 @@
       },
       {
         "internalType": "bytes",
-        "name": "validatorPubkey",
+        "name": "validatorID",
         "type": "bytes"
       },
       {

--- a/precompiles/assets/tx.go
+++ b/precompiles/assets/tx.go
@@ -66,7 +66,7 @@ func (p Precompile) DepositOrWithdraw(
 			depositWithdrawParams.StakerAddress, depositWithdrawParams.AssetsAddress)
 		err = p.assetsKeeper.UpdateNSTValidatorListForStaker(ctx, assetID,
 			hexutil.Encode(depositWithdrawParams.StakerAddress),
-			hexutil.Encode(depositWithdrawParams.ValidatorPubkey),
+			hexutil.Encode(depositWithdrawParams.ValidatorID),
 			opAmount)
 		if err != nil {
 			return nil, err

--- a/precompiles/assets/types.go
+++ b/precompiles/assets/types.go
@@ -63,14 +63,16 @@ func (p Precompile) DepositWithdrawParams(ctx sdk.Context, method *abi.Method, a
 			depositWithdrawParams.Action = assetstypes.WithdrawLST
 		}
 	case MethodDepositNST, MethodWithdrawNST:
-		validatorPubkey, ok := args[1].([]byte)
-		if !ok || len(validatorPubkey) == 0 {
+		validatorID, ok := args[1].([]byte)
+		// the length of the public key / identifier is not fixed. it depends on the source chain.
+		// for example, in Ethereum we have a uint256 == validator index but in Sui it is 96 bytes.
+		if !ok || len(validatorID) == 0 {
 			return nil, fmt.Errorf(exocmn.ErrContractInputParaOrType, 1, "[]byte", args[1])
 		}
 		// generate the virtual address for native restaking asset
 		depositWithdrawParams.AssetsAddress = assetstypes.GenerateNSTAddr(clientChainAddrLength)
 		// todo: add a check for the validator pubkey
-		depositWithdrawParams.ValidatorPubkey = validatorPubkey
+		depositWithdrawParams.ValidatorID = validatorID
 		if method.Name == MethodDepositNST {
 			depositWithdrawParams.Action = assetstypes.DepositNST
 		} else {

--- a/x/assets/keeper/bank.go
+++ b/x/assets/keeper/bank.go
@@ -15,7 +15,7 @@ type DepositWithdrawParams struct {
 	AssetsAddress   []byte
 	StakerAddress   []byte
 	OpAmount        sdkmath.Int
-	ValidatorPubkey []byte
+	ValidatorID     []byte
 }
 
 // PerformDepositOrWithdraw the assets precompile contract will call this function to update asset state


### PR DESCRIPTION
Excludes changes in x/oracle and the price feeder

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced clarity in validator identification by renaming parameters from `validatorPubkey` to `validatorID` across multiple functions and methods.

- **Bug Fixes**
	- Improved documentation and comments for better understanding of the validator identifier's usage and variability.

- **Refactor**
	- Streamlined parameter names for consistency and semantic clarity without altering the underlying functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->