### PR TITLE
fix(epochs): block `null` epoch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /go/src/github.com/ExocoreNetwork/exocore
 
 COPY go.mod go.sum ./
 
-RUN apk add --no-cache ca-certificates=20241121-r0 build-base=0.5-r3 git=2.43.5-r0 linux-headers=6.5-r0
+RUN apk add --no-cache ca-certificates=20241121-r1 build-base=0.5-r3 git=2.43.5-r0 linux-headers=6.5-r0
 
 RUN --mount=type=bind,target=. --mount=type=secret,id=GITHUB_TOKEN \
     git config --global url."https://$(cat /run/secrets/GITHUB_TOKEN)@github.com/".insteadOf "https://github.com/"; \
@@ -23,7 +23,7 @@ WORKDIR /root
 COPY --from=build-env /go/src/github.com/ExocoreNetwork/exocore/build/exocored /usr/bin/exocored
 COPY --from=build-env /go/bin/toml-cli /usr/bin/toml-cli
 
-RUN apk add --no-cache ca-certificates=20241121-r0 libstdc++=13.2.1_git20231014-r0 jq=1.7.1-r0 curl=8.11.1-r0 bash=5.2.21-r0 vim=9.0.2127-r0 lz4=1.9.4-r5 rclone=1.65.0-r3 \
+RUN apk add --no-cache ca-certificates=20241121-r1 libstdc++=13.2.1_git20231014-r0 jq=1.7.1-r0 curl=8.11.1-r0 bash=5.2.21-r0 vim=9.0.2127-r0 lz4=1.9.4-r5 rclone=1.65.0-r3 \
     && addgroup -g 1000 exocore \
     && adduser -S -h /home/exocore -D exocore -u 1000 -G exocore
 

--- a/x/epochs/types/genesis.go
+++ b/x/epochs/types/genesis.go
@@ -42,15 +42,13 @@ func (gs GenesisState) Validate() error {
 // Validate validates epoch info. Since it does not particularly pertain to genesis data,
 // the error is returned as-is and not wrapped with ErrInvalidGenesisData.
 func (epoch EpochInfo) Validate() error {
-	if epoch.Identifier == "" {
-		return errors.New("epoch identifier should NOT be empty")
-	}
-	if epoch.Identifier == NullEpochIdentifier {
-		return errors.New("epoch identifier should NOT be virtual null epoch")
+	if err := ValidateEpochIdentifierString(epoch.Identifier); err != nil {
+		return err
 	}
 	if epoch.Duration <= 0 {
 		return errors.New("epoch duration should NOT be non-positive")
 	}
+	// the EpochNumber may be 0 at genesis so we don't validate that.
 	if epoch.CurrentEpoch < 0 {
 		return errors.New("epoch CurrentEpoch must be non-negative")
 	}

--- a/x/epochs/types/genesis_test.go
+++ b/x/epochs/types/genesis_test.go
@@ -63,7 +63,7 @@ func (suite *GenesisTestSuite) TestValidateGenesis() {
 				},
 			),
 			expPass:  false,
-			expError: "epoch identifier should NOT be empty",
+			expError: "empty epoch identifier",
 		},
 		{
 			name: "zero epoch duration",

--- a/x/epochs/types/identifier.go
+++ b/x/epochs/types/identifier.go
@@ -17,7 +17,7 @@ const (
 
 	// NullEpochIdentifier and NullEpochNumber are used to construct the key for undelegations
 	// that aren't restricted by any AVS unbonding configuration.
-	// So it's a virtual epoch configuration, it shouldn't be configured in the genesis
+	// Since it's a virtual epoch configuration, it shouldn't be configured in the genesis.
 	NullEpochIdentifier = "NullEpoch"
 	NullEpochNumber     = int64(0)
 )
@@ -37,13 +37,12 @@ func ValidateEpochIdentifierInterface(i interface{}) error {
 	return nil
 }
 
-// ValidateEpochIdentifierString accepts a string and validates it as an epoch identifier.
-// It is not used directly by this module; rather it is created for other modules to validate
-// their params.
+// ValidateEpochIdentifierString accepts a string and validates it as an epoch identifier. It
+// is a convenience method more often used by other modules.
 func ValidateEpochIdentifierString(s string) error {
 	s = strings.TrimSpace(s)
 	if s == "" {
-		return fmt.Errorf("empty distribution epoch identifier: %+v", s)
+		return fmt.Errorf("empty epoch identifier: %+v", s)
 	}
 	if s == NullEpochIdentifier {
 		return fmt.Errorf("epoch identifier cannot be the null epoch identifier: %+v", s)
@@ -51,7 +50,8 @@ func ValidateEpochIdentifierString(s string) error {
 	return nil
 }
 
-// ValidateEpoch accepts an Epoch and validates it. The validation performed is that the epoch identifier string is valid, and that the epoch number (uint64) is not zero.
+// ValidateEpoch accepts an Epoch and validates it. The validation performed is that the epoch identifier string is
+// valid, and that the epoch number (uint64) is not zero.
 func ValidateEpoch(epoch Epoch) error {
 	if err := ValidateEpochIdentifierString(epoch.EpochIdentifier); err != nil {
 		return err

--- a/x/epochs/types/identifier.go
+++ b/x/epochs/types/identifier.go
@@ -45,6 +45,9 @@ func ValidateEpochIdentifierString(s string) error {
 	if s == "" {
 		return fmt.Errorf("empty distribution epoch identifier: %+v", s)
 	}
+	if s == NullEpochIdentifier {
+		return fmt.Errorf("epoch identifier cannot be the null epoch identifier: %+v", s)
+	}
 	return nil
 }
 

--- a/x/epochs/types/identifier_test.go
+++ b/x/epochs/types/identifier_test.go
@@ -1,0 +1,127 @@
+package types_test
+
+import (
+	"testing"
+
+	"github.com/ExocoreNetwork/exocore/x/epochs/types"
+)
+
+const (
+	invalidEpochIDByType = uint64(0)
+	invalidEpochIDByName = " "
+	validEpochID         = " hello "
+	nullEpochIDByName    = types.NullEpochIdentifier
+)
+
+var (
+	validEpoch            = types.NewEpoch(1, validEpochID)
+	invalidEpochInterface = struct{}{}
+	invalidEpochString    = types.NewEpoch(1, invalidEpochIDByName)
+	invalidEpochNumber    = types.NewEpoch(0, validEpochID)
+)
+
+func TestValidateEpochIdentifierInterface(t *testing.T) {
+	t.Run("invalid epoch identifier by type", func(t *testing.T) {
+		err := types.ValidateEpochIdentifierInterface(invalidEpochIDByType)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+
+	t.Run("invalid epoch identifier by name", func(t *testing.T) {
+		err := types.ValidateEpochIdentifierInterface(invalidEpochIDByName)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+
+	t.Run("null epoch identifier", func(t *testing.T) {
+		err := types.ValidateEpochIdentifierInterface(nullEpochIDByName)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+
+	t.Run("valid epoch identifier", func(t *testing.T) {
+		err := types.ValidateEpochIdentifierInterface(validEpochID)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
+func TestValidateEpochIdentifierString(t *testing.T) {
+	t.Run("invalid epoch identifier by name", func(t *testing.T) {
+		err := types.ValidateEpochIdentifierString(invalidEpochIDByName)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+
+	t.Run("null epoch identifier", func(t *testing.T) {
+		err := types.ValidateEpochIdentifierString(nullEpochIDByName)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+
+	t.Run("valid epoch identifier", func(t *testing.T) {
+		err := types.ValidateEpochIdentifierString(validEpochID)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
+func TestValidateEpochInterface(t *testing.T) {
+	t.Run("invalid epoch by type", func(t *testing.T) {
+		err := types.ValidateEpochInterface(invalidEpochInterface)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+
+	t.Run("invalid epoch by string", func(t *testing.T) {
+		err := types.ValidateEpochInterface(invalidEpochString)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+
+	t.Run("invalid epoch by number", func(t *testing.T) {
+		err := types.ValidateEpochInterface(invalidEpochNumber)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+
+	t.Run("valid epoch", func(t *testing.T) {
+		err := types.ValidateEpochInterface(validEpoch)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
+func TestValidateEpoch(t *testing.T) {
+	t.Run("invalid epoch by string", func(t *testing.T) {
+		err := types.ValidateEpoch(invalidEpochString)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+
+	t.Run("invalid epoch by number", func(t *testing.T) {
+		err := types.ValidateEpoch(invalidEpochNumber)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+
+	t.Run("valid epoch", func(t *testing.T) {
+		err := types.ValidateEpoch(validEpoch)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
The `null` epoch is an internal epoch used to track undelegation. It should not be permitted as an identifier.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security Updates**
	- Updated `ca-certificates` package to version 20241121-r1 in Docker build environment and final image.

- **Validation Improvements**
	- Enhanced epoch identifier validation with a new validation function.
	- Added more descriptive error messages for epoch identifier checks.
	- Clarified validation rules for epoch-related structs.

- **Documentation**
	- Improved comments and error message clarity in epoch-related code.
  
- **Tests**
	- Introduced new test functions to validate epoch identifiers and epochs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->