### PR TITLE
feat(upgrade): add the missed consensus version

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1150,6 +1150,9 @@ func (app *ExocoreApp) BeginBlocker(
 	req abci.RequestBeginBlock,
 ) abci.ResponseBeginBlock {
 	// Perform any scheduled forks before executing the modules logic
+	// todo: This needs to be enabled only when we hard-code the upgrade plan to
+	// address the mainnet upgrade. This approach will be used when governance
+	// is not enabled.
 	app.ScheduleForkUpgrade(ctx)
 	return app.mm.BeginBlock(ctx, req)
 }

--- a/x/assets/module.go
+++ b/x/assets/module.go
@@ -20,6 +20,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// consensusVersion defines the current x/assets module consensus version.
+// the initial version should be 1
+const consensusVersion = 1
+
 // type check to ensure the interface is properly implemented
 var (
 	_ module.AppModule           = AppModule{}
@@ -133,3 +137,6 @@ func (am AppModule) RegisterStoreDecoder(_ sdk.StoreDecoderRegistry) {
 func (am AppModule) WeightedOperations(_ module.SimulationState) []simtypes.WeightedOperation {
 	return []simtypes.WeightedOperation{}
 }
+
+// ConsensusVersion implements AppModule/ConsensusVersion.
+func (AppModule) ConsensusVersion() uint64 { return consensusVersion }

--- a/x/avs/module.go
+++ b/x/avs/module.go
@@ -21,6 +21,9 @@ import (
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
 )
 
+// consensusVersion defines the current x/avs module consensus version.
+const consensusVersion = 1
+
 // type check to ensure the interface is properly implemented
 var (
 	_ module.AppModule           = AppModule{}
@@ -137,3 +140,6 @@ func (am AppModule) ExportGenesis(ctx sdk.Context, cdc codec.JSONCodec) json.Raw
 	genState := am.keeper.ExportGenesis(ctx)
 	return cdc.MustMarshalJSON(genState)
 }
+
+// ConsensusVersion implements AppModule/ConsensusVersion.
+func (AppModule) ConsensusVersion() uint64 { return consensusVersion }

--- a/x/delegation/keeper/un_delegation_state.go
+++ b/x/delegation/keeper/un_delegation_state.go
@@ -257,7 +257,6 @@ func (k *Keeper) GetCompletableUndelegations(ctx sdk.Context) ([]*types.Undelega
 	// iterate all pending undelegations across multiple epochs.
 	allEpochs := k.epochsKeeper.AllEpochInfos(ctx)
 	for _, epochInfo := range allEpochs {
-		ctx.Logger().Info("GetCompletableUndelegations", "epochInfo", epochInfo.Identifier, "epochNumber", epochInfo.CurrentEpoch)
 		err := k.IteratePendingUndelegations(ctx, true, epochInfo.Identifier, epochInfo.CurrentEpoch, expiredUndelegationOpFunc)
 		if err != nil {
 			return nil, err

--- a/x/delegation/module.go
+++ b/x/delegation/module.go
@@ -19,6 +19,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// consensusVersion defines the current x/delegation module consensus version.
+const consensusVersion = 1
+
 // type check to ensure the interface is properly implemented
 var (
 	_ module.AppModule           = AppModule{}
@@ -140,3 +143,6 @@ func (am AppModule) ExportGenesis(ctx sdk.Context, cdc codec.JSONCodec) json.Raw
 	genState := am.keeper.ExportGenesis(ctx)
 	return cdc.MustMarshalJSON(genState)
 }
+
+// ConsensusVersion implements AppModule/ConsensusVersion.
+func (AppModule) ConsensusVersion() uint64 { return consensusVersion }

--- a/x/operator/module.go
+++ b/x/operator/module.go
@@ -19,6 +19,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// consensusVersion defines the current x/operator module consensus version.
+const consensusVersion = 1
+
 // type check to ensure the interface is properly implemented
 var (
 	_ module.AppModule           = AppModule{}
@@ -138,3 +141,6 @@ func (am AppModule) ExportGenesis(ctx sdk.Context, cdc codec.JSONCodec) json.Raw
 	genState := am.keeper.ExportGenesis(ctx)
 	return cdc.MustMarshalJSON(genState)
 }
+
+// ConsensusVersion implements AppModule/ConsensusVersion.
+func (AppModule) ConsensusVersion() uint64 { return consensusVersion }


### PR DESCRIPTION
## Description

This PR adds the missing consensus version for some modules and adds some code comments for future upgrades. This PR serves to prepare for the mainnet upgrade.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added consensus version tracking for multiple modules (Assets, AVS, Delegation, Operator)
	- Introduced module-level versioning mechanism

- **Chores**
	- Removed verbose logging in delegation undelegation state retrieval
	- Added clarifying comment about fork upgrade scheduling in app initialization
<!-- end of auto-generated comment: release notes by coderabbit.ai -->