### PR TITLE
fix(docker): bring back curl 8.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN apk add --no-cache \
 	ca-certificates=20241121-r1 \
 	libstdc++~=13.2 \
 	jq~=1.7 \
-	curl~=8.11 \
+	curl~=8.12 \
 	bash~=5.2 \
     && addgroup -g 1000 exocore \
     && adduser -S -h /home/exocore -D exocore -u 1000 -G exocore

--- a/networks/local/exocore/Dockerfile
+++ b/networks/local/exocore/Dockerfile
@@ -12,7 +12,7 @@ RUN LEDGER_ENABLED=false make build
 FROM alpine:3.19 AS run
 RUN apk add --no-cache libstdc++~=13.2 \
 	bash~=5.2 \
-	curl~=8.11 \
+	curl~=8.12 \
 	jq~=1.7 \
     && addgroup -g 1000 exocore \
     && adduser -S -h /home/exocore -D exocore -u 1000 -G exocore


### PR DESCRIPTION
Alpine has restored curl 8.12 to the 3.19 repos

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Upgraded the curl package to a newer stable version, ensuring improved reliability and access to the latest fixes and enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->