### PR TITLE
feat(gov): disable the governance through set null router

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -88,9 +88,7 @@ import (
 	ibctransfer "github.com/cosmos/ibc-go/v7/modules/apps/transfer"
 	ibctransfertypes "github.com/cosmos/ibc-go/v7/modules/apps/transfer/types"
 	ibc "github.com/cosmos/ibc-go/v7/modules/core"
-	ibcclient "github.com/cosmos/ibc-go/v7/modules/core/02-client"
 	ibcclientclient "github.com/cosmos/ibc-go/v7/modules/core/02-client/client"
-	ibcclienttypes "github.com/cosmos/ibc-go/v7/modules/core/02-client/types"
 	porttypes "github.com/cosmos/ibc-go/v7/modules/core/05-port/types"
 	ibcexported "github.com/cosmos/ibc-go/v7/modules/core/exported"
 	ibckeeper "github.com/cosmos/ibc-go/v7/modules/core/keeper"
@@ -162,8 +160,6 @@ import (
 	paramsclient "github.com/cosmos/cosmos-sdk/x/params/client"
 	paramskeeper "github.com/cosmos/cosmos-sdk/x/params/keeper"
 	paramstypes "github.com/cosmos/cosmos-sdk/x/params/types"
-	paramproposal "github.com/cosmos/cosmos-sdk/x/params/types/proposal"
-
 	"github.com/cosmos/cosmos-sdk/x/slashing"
 	slashingkeeper "github.com/cosmos/cosmos-sdk/x/slashing/keeper"
 	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
@@ -640,17 +636,19 @@ func NewImuachainApp(
 	// add the governance module, with first step being setting up the proposal types.
 	// any new proposals that are created within any module must be added here.
 	govRouter := govv1beta1.NewRouter()
-	govRouter.AddRoute(govtypes.RouterKey, govv1beta1.ProposalHandler).
+	// TODO: Disable governance during the early phase of mainnet. It should be uncommented when
+	// governance is enabled.
+	/*	govRouter.AddRoute(govtypes.RouterKey, govv1beta1.ProposalHandler).
 		AddRoute(paramproposal.RouterKey, params.NewParamChangeProposalHandler(app.ParamsKeeper)).
 		AddRoute(upgradetypes.RouterKey, upgrade.NewSoftwareUpgradeProposalHandler(&app.UpgradeKeeper)).
 		AddRoute(ibcclienttypes.RouterKey, ibcclient.NewClientProposalHandler(app.IBCKeeper.ClientKeeper)).
-		AddRoute(erc20types.RouterKey, erc20.NewErc20ProposalHandler(&app.Erc20Keeper))
+		AddRoute(erc20types.RouterKey, erc20.NewErc20ProposalHandler(&app.Erc20Keeper))*/
 	app.GovKeeper = *govkeeper.NewKeeper(
 		appCodec, keys[govtypes.StoreKey], app.AccountKeeper, app.BankKeeper,
 		// must be a pointer, since it is not yet initialized
 		// (but could alternatively make governance keeper later)
 		&app.StakingKeeper,
-		app.MsgServiceRouter(), govtypes.DefaultConfig(), authAddrString,
+		baseapp.NewMsgServiceRouter(), govtypes.DefaultConfig(), authAddrString,
 	)
 	// Set legacy router for backwards compatibility with gov v1beta1
 	(&app.GovKeeper).SetLegacyRouter(govRouter)


### PR DESCRIPTION
## Description

Max has already added the authority check for all modules when updating parameters. So, this PR only disables governance by setting the routers to null, including both `MsgServiceRouter` and `legacyRouter`.

During the early phase of mainnet, the parameters can be updated through a node upgrade without enabling the governance module. An example of updating the gateways is provided in this documentation:
[updating gateways by node upgrade](https://www.notion.so/exocore/upgrade-and-cosmovisor-182612d2b5df80b7bd19d89d7dfbe5d1?pvs=4#182612d2b5df806a9e20f1b5c5b53232)

Additionally, I am unsure whether we should provide a precompile interface to update the list of assets supported by Dogfood. This interface should be controlled by the owner of the gateway contract, similar to the `registerToken`. It would allow us to add supported assets for the Dogfood AVS without upgrading the node. I can add it in this PR if we think it's necessary.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Temporarily disabled governance functionality during the early mainnet phase.
  - Updated message routing within the governance module to align with the transitional state.

These changes are designed to facilitate the platform's adaptation to the evolving mainnet environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->