### PR TITLE
fix: genesis validation

### DIFF
--- a/x/appchain/coordinator/types/msg.go
+++ b/x/appchain/coordinator/types/msg.go
@@ -47,7 +47,7 @@ func (msg *RegisterSubscriberChainRequest) ValidateBasic() error {
 		if _, _, err := assetstypes.ValidateID(
 			assetID,
 			true, // the caller must make them lowercase
-			true, // TODO: we support only Ethereum assets for now.
+			false,
 		); err != nil {
 			return fmt.Errorf("invalid asset id %s: %s", assetID, err)
 		}

--- a/x/assets/types/genesis.go
+++ b/x/assets/types/genesis.go
@@ -124,7 +124,7 @@ func (gs GenesisState) ValidateDeposits(lzIDs map[uint64]struct{}, tokensTotalSt
 		// validate the stakerID
 		var stakerClientChainID uint64
 		var err error
-		if _, stakerClientChainID, err = ValidateID(stakerID, true, true); err != nil {
+		if _, stakerClientChainID, err = ValidateID(stakerID, true, false); err != nil {
 			return errorsmod.Wrapf(
 				ErrInvalidGenesisData,
 				"invalid stakerID: %s",

--- a/x/operator/types/genesis.go
+++ b/x/operator/types/genesis.go
@@ -61,14 +61,17 @@ func (gs GenesisState) ValidateOperators() (map[string]struct{}, error) {
 				"invalid operator address %s: %s", address, err,
 			)
 		}
-		if op.OperatorInfo.EarningsAddr != "" {
-			_, err := sdk.AccAddressFromBech32(op.OperatorInfo.EarningsAddr)
-			if err != nil {
-				return nil, errorsmod.Wrapf(
-					ErrInvalidGenesisData,
-					"invalid operator earning address %s: %s", op.OperatorInfo.EarningsAddr, err,
-				)
-			}
+		if op.OperatorInfo.EarningsAddr != address {
+			return nil, errorsmod.Wrapf(
+				ErrInvalidGenesisData,
+				"operator address %s has earnings address %s", address, op.OperatorInfo.EarningsAddr,
+			)
+		}
+		if op.OperatorInfo.ApproveAddr != address {
+			return nil, errorsmod.Wrapf(
+				ErrInvalidGenesisData,
+				"operator address %s has approve address %s", address, op.OperatorInfo.ApproveAddr,
+			)
 		}
 		operators[address] = struct{}{}
 		if op.OperatorInfo.ClientChainEarningsAddr != nil {


### PR DESCRIPTION
- Check that operator address, earnings address and approve address are all the same
- Do not vaidate that asset address is Ethereum only; support others

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Relaxed asset ID validation to allow mixed-case input during subscriptions and deposits.
	- Enhanced operator validation by ensuring that both earnings and approval addresses match the operator’s address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->