### PR TITLE
fix(build): `make swagger-ui` to not use `pwd`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -643,4 +643,4 @@ check-licenses:
 	@python3 scripts/check_licenses.py .
 
 swagger-ui:
-	docker run -p 8080:8080 -e SWAGGER_JSON=/app/swagger.json -v $(pwd)/client/docs/swagger-ui:/app swaggerapi/swagger-ui
+	docker run --rm -p 8080:8080 -e SWAGGER_JSON=/app/swagger.json -v $(CURDIR)/client/docs/swagger-ui:/app swaggerapi/swagger-ui


### PR DESCRIPTION
Usage of `$(pwd)` is not supported within the `Makefile`. Instead `$(CURDIR)` must be used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved consistency and cleanup for running Swagger UI by updating internal handling of the Docker container and directory paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->