### PR TITLE
fix(unbonding): Refine instant unbonding

### DIFF
--- a/app/ethtest_helper.go
+++ b/app/ethtest_helper.go
@@ -237,7 +237,7 @@ func genesisStateWithValSet(codec codec.Codec, genesisState simapp.GenesisState,
 			},
 		},
 	}
-	delegationGenesis := delegationtypes.NewGenesis(associations, delegationStates, stakersByOperator, nil)
+	delegationGenesis := delegationtypes.NewGenesis(delegationtypes.DefaultParams(), associations, delegationStates, stakersByOperator, nil)
 	genesisState[delegationtypes.ModuleName] = codec.MustMarshalJSON(delegationGenesis)
 
 	dogfoodGenesis := dogfoodtypes.NewGenesis(

--- a/app/test_helpers.go
+++ b/app/test_helpers.go
@@ -278,7 +278,7 @@ func GenesisStateWithValSet(app *ImuachainApp, genesisState simapp.GenesisState,
 			},
 		},
 	}
-	delegationGenesis := delegationtypes.NewGenesis(associations, delegationStates, stakersByOperator, nil)
+	delegationGenesis := delegationtypes.NewGenesis(delegationtypes.DefaultParams(), associations, delegationStates, stakersByOperator, nil)
 	genesisState[delegationtypes.ModuleName] = app.AppCodec().MustMarshalJSON(delegationGenesis)
 
 	// create a dogfood genesis with just the validator set, that is, the bare

--- a/cmd/imuad/testnet.go
+++ b/cmd/imuad/testnet.go
@@ -463,7 +463,7 @@ func getTestImuachainGenesis(
 			}, depositsByStaker, nil,
 		), operatortypes.NewGenesisState(
 			operatorInfos, nil, nil, nil, nil, nil, nil, nil,
-		), delegationtypes.NewGenesis(associations, delegationStates, stakersByOperator, nil), dogfoodtypes.NewGenesis(
+		), delegationtypes.NewGenesis(delegationtypes.DefaultParams(), associations, delegationStates, stakersByOperator, nil), dogfoodtypes.NewGenesis(
 			dogfoodtypes.NewParams(
 				dogfoodtypes.DefaultEpochsUntilUnbonded,
 				dogfoodtypes.DefaultEpochIdentifier,

--- a/precompiles/delegation/tx.go
+++ b/precompiles/delegation/tx.go
@@ -85,11 +85,7 @@ func (p Precompile) Undelegate(
 	}
 	undelegationParams.TxHash = txHash
 
-	if undelegationParams.InstantUnbonding {
-		err = p.delegationKeeper.InstantUndelegateFrom(ctx, undelegationParams)
-	} else {
-		err = p.delegationKeeper.UndelegateFrom(ctx, undelegationParams)
-	}
+	err = p.delegationKeeper.UndelegateFrom(ctx, undelegationParams)
 	if err != nil {
 		return nil, err
 	}

--- a/precompiles/delegation/types.go
+++ b/precompiles/delegation/types.go
@@ -35,7 +35,7 @@ func (p Precompile) GetDelegationParamsFromInputs(ctx sdk.Context, args []interf
 	// the length of client chain address inputted by caller is 32, so we need to check the length and remove the padding according to the actual length.
 	assetAddr, ok := args[1].([]byte)
 	if !ok || assetAddr == nil {
-		return nil, fmt.Errorf(imuacmn.ErrContractInputParamOrType, 2, "[]byte", args[2])
+		return nil, fmt.Errorf(imuacmn.ErrContractInputParamOrType, 1, "[]byte", args[1])
 	}
 	// #nosec G115
 	if uint32(len(assetAddr)) < clientChainAddrLength {
@@ -45,7 +45,7 @@ func (p Precompile) GetDelegationParamsFromInputs(ctx sdk.Context, args []interf
 
 	stakerAddr, ok := args[2].([]byte)
 	if !ok || stakerAddr == nil {
-		return nil, fmt.Errorf(imuacmn.ErrContractInputParamOrType, 3, "[]byte", args[3])
+		return nil, fmt.Errorf(imuacmn.ErrContractInputParamOrType, 2, "[]byte", args[2])
 	}
 	// #nosec G115
 	if uint32(len(stakerAddr)) < clientChainAddrLength {
@@ -56,7 +56,7 @@ func (p Precompile) GetDelegationParamsFromInputs(ctx sdk.Context, args []interf
 	// the input operator address is cosmos accAddress type,so we need to check the length and decode it through Bench32
 	operatorAddr, ok := args[3].([]byte)
 	if !ok || operatorAddr == nil {
-		return nil, fmt.Errorf(imuacmn.ErrContractInputParamOrType, 4, "[]byte", args[4])
+		return nil, fmt.Errorf(imuacmn.ErrContractInputParamOrType, 3, "[]byte", args[3])
 	}
 	if len(operatorAddr) != types.ImuachainOperatorAddrLength {
 		return nil, fmt.Errorf(imuacmn.ErrInputOperatorAddrLength, len(operatorAddr), types.ImuachainOperatorAddrLength)
@@ -70,8 +70,16 @@ func (p Precompile) GetDelegationParamsFromInputs(ctx sdk.Context, args []interf
 
 	opAmount, ok := args[4].(*big.Int)
 	if !ok || opAmount == nil || !(opAmount.Cmp(big.NewInt(0)) == 1) {
-		return nil, fmt.Errorf(imuacmn.ErrContractInputParamOrType, 5, "*big.Int", args[5])
+		return nil, fmt.Errorf(imuacmn.ErrContractInputParamOrType, 4, "*big.Int", args[4])
 	}
 	delegationParams.OpAmount = sdkmath.NewIntFromBigInt(opAmount)
+
+	if method == MethodUndelegate {
+		isInstantUnbonding, ok := args[5].(bool)
+		if !ok {
+			return nil, fmt.Errorf(imuacmn.ErrContractInputParamOrType, 5, "bool", args[5])
+		}
+		delegationParams.InstantUnbonding = isInstantUnbonding
+	}
 	return delegationParams, nil
 }

--- a/testutil/utils.go
+++ b/testutil/utils.go
@@ -412,7 +412,7 @@ func (suite *BaseTestSuite) SetupWithGenesisValSet(genAccs []authtypes.GenesisAc
 			},
 		},
 	}
-	delegationGenesis := delegationtypes.NewGenesis(associations, delegationStates, stakersByOperator, nil)
+	delegationGenesis := delegationtypes.NewGenesis(delegationtypes.DefaultParams(), associations, delegationStates, stakersByOperator, nil)
 	genesisState[delegationtypes.ModuleName] = app.AppCodec().MustMarshalJSON(delegationGenesis)
 
 	// create a dogfood genesis with just the validator set, that is, the bare

--- a/x/assets/keeper/staker_asset_test.go
+++ b/x/assets/keeper/staker_asset_test.go
@@ -2,6 +2,7 @@ package keeper_test
 
 import (
 	"fmt"
+
 	assetstype "github.com/imua-xyz/imuachain/x/assets/types"
 
 	"cosmossdk.io/math"

--- a/x/delegation/client/cli/tx_delegation_native.go
+++ b/x/delegation/client/cli/tx_delegation_native.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"errors"
-	"strconv"
 
 	sdkmath "cosmossdk.io/math"
 
@@ -12,6 +11,10 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/imua-xyz/imuachain/x/delegation/types"
+)
+
+const (
+	FlagInstantUnbonding = "instant-unbonding"
 )
 
 func CmdDelegate() *cobra.Command {
@@ -42,20 +45,20 @@ func CmdDelegate() *cobra.Command {
 func CmdUndelegate() *cobra.Command {
 	cmd := &cobra.Command{
 		// TODO: only support native token for now
-		Use:   "undelegate asset-id operator amount instant-unbonding",
+		Use:   "undelegate asset-id operator amount optional(--instant-unbonding true)",
 		Short: "Broadcast a transaction to undelegate amount of native token from the operator",
-		Args:  cobra.ExactArgs(4),
+		Args:  cobra.ExactArgs(3),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			clientCtx, err := client.GetClientTxContext(cmd)
 			if err != nil {
 				return err
 			}
 
-			assetID, operatorAddrStr, amount, err := parseArgs(args[:3])
+			assetID, operatorAddrStr, amount, err := parseArgs(args)
 			if err != nil {
 				return err
 			}
-			instantUnbonding, err := strconv.ParseBool(args[3])
+			instantUnbonding, err := cmd.Flags().GetBool(FlagInstantUnbonding)
 			if err != nil {
 				return err
 			}
@@ -65,7 +68,7 @@ func CmdUndelegate() *cobra.Command {
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
 		},
 	}
-
+	cmd.Flags().Bool(FlagInstantUnbonding, false, "indicate whether it's an instant undelegation")
 	flags.AddTxFlagsToCmd(cmd)
 	return cmd
 }

--- a/x/delegation/client/cli/tx_delegation_native.go
+++ b/x/delegation/client/cli/tx_delegation_native.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"errors"
+	"strconv"
 
 	sdkmath "cosmossdk.io/math"
 
@@ -41,21 +42,25 @@ func CmdDelegate() *cobra.Command {
 func CmdUndelegate() *cobra.Command {
 	cmd := &cobra.Command{
 		// TODO: only support native token for now
-		Use:   "undelegate asset-id operator amount",
+		Use:   "undelegate asset-id operator amount instant-unbonding",
 		Short: "Broadcast a transaction to undelegate amount of native token from the operator",
-		Args:  cobra.ExactArgs(3),
+		Args:  cobra.ExactArgs(4),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			clientCtx, err := client.GetClientTxContext(cmd)
 			if err != nil {
 				return err
 			}
 
-			assetID, operatorAddrStr, amount, err := parseArgs(args)
+			assetID, operatorAddrStr, amount, err := parseArgs(args[:3])
+			if err != nil {
+				return err
+			}
+			instantUnbonding, err := strconv.ParseBool(args[3])
 			if err != nil {
 				return err
 			}
 
-			msg := types.NewMsgUndelegation(assetID, clientCtx.GetFromAddress().String(), []types.KeyValue{{Key: operatorAddrStr, Value: &types.ValueField{Amount: amount}}})
+			msg := types.NewMsgUndelegation(instantUnbonding, assetID, clientCtx.GetFromAddress().String(), []types.KeyValue{{Key: operatorAddrStr, Value: &types.ValueField{Amount: amount}}})
 
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
 		},

--- a/x/delegation/keeper/delegation.go
+++ b/x/delegation/keeper/delegation.go
@@ -132,103 +132,8 @@ func (k *Keeper) delegateTo(
 	return nil
 }
 
-// InstantUndelegateFrom undelegates asset from operator with instant unbonding
-func (k *Keeper) InstantUndelegateFrom(ctx sdk.Context, params *delegationtype.DelegationOrUndelegationParams) error {
-	if !params.OpAmount.IsPositive() {
-		return delegationtype.ErrAmountIsNotPositive
-	}
-
-	// check if the UndelegatedFrom address is an operator
-	if !k.operatorKeeper.IsOperator(ctx, params.OperatorAddress) {
-		return delegationtype.ErrOperatorNotExist
-	}
-
-	// Get staker and asset IDs
-	stakerID, assetID := assetstype.GetStakerIDAndAssetID(params.ClientChainID, params.StakerAddress, params.AssetsAddress)
-
-	undelegationID := k.GetLastUndelegationID(ctx)
-
-	// verify the undelegation amount
-	share, err := k.ValidateUndelegationAmount(ctx, params.OperatorAddress, stakerID, assetID, params.OpAmount)
-	if err != nil {
-		return err
-	}
-
-	// remove share
-	removeToken, err := k.RemoveShare(ctx, true, params.OperatorAddress, stakerID, assetID, share)
-	if err != nil {
-		return err
-	}
-
-	// Create undelegation record
-	r := delegationtype.UndelegationRecord{
-		StakerId:              stakerID,
-		AssetId:               assetID,
-		OperatorAddr:          params.OperatorAddress.String(),
-		TxHash:                params.TxHash.String(),
-		UndelegationId:        undelegationID,
-		BlockNumber:           uint64(ctx.BlockHeight()),
-		Amount:                removeToken,
-		ActualCompletedAmount: removeToken,
-	}
-
-	// Get current epoch info
-	completedEpochID, completedEpochNumber, err := k.operatorKeeper.GetUnbondingExpiration(ctx, params.OperatorAddress)
-	if err != nil {
-		return err
-	}
-
-	epochInfo, found := k.epochsKeeper.GetEpochInfo(ctx, completedEpochID)
-	if !found {
-		return errorsmod.Wrapf(delegationtype.ErrEpochIdentifierNotExist, "identifier:%s", completedEpochID)
-	}
-
-	// Apply instant penalty only when the completion epoch is more than one epoch away
-	if completedEpochNumber-epochInfo.CurrentEpoch > 1 {
-		// Get the instant undelegation penalty
-		penalty := k.GetInstantUndelegationPenalty(ctx)
-		penaltyAmount := params.OpAmount.Mul(sdk.NewInt(int64(penalty))).Quo(sdk.NewInt(100))
-		r.ActualCompletedAmount = r.ActualCompletedAmount.Sub(penaltyAmount)
-		r.CompletedEpochNumber = epochInfo.CurrentEpoch + 1
-	} else {
-		r.CompletedEpochNumber = completedEpochNumber
-	}
-
-	r.CompletedEpochIdentifier = completedEpochID
-
-	// Store record and increment ID
-	if err := k.SetUndelegationRecords(ctx, false, []delegationtype.UndelegationAndHoldCount{{Undelegation: &r}}); err != nil {
-		return err
-	}
-	if err := k.IncrementLastUndelegationID(ctx); err != nil {
-		return err
-	}
-
-	recordKey := r.GetKey()
-
-	// Emit event
-	ctx.EventManager().EmitEvent(
-		sdk.NewEvent(
-			delegationtype.EventTypeUndelegationStarted,
-			sdk.NewAttribute(delegationtype.AttributeKeyStakerID, r.StakerId),
-			sdk.NewAttribute(delegationtype.AttributeKeyAssetID, r.AssetId),
-			sdk.NewAttribute(delegationtype.AttributeKeyOperator, r.OperatorAddr),
-			sdk.NewAttribute(delegationtype.AttributeKeyRecordID, hexutil.Encode(recordKey)),
-			sdk.NewAttribute(delegationtype.AttributeKeyAmount, r.Amount.String()),
-			sdk.NewAttribute(delegationtype.AttributeKeyCompletedEpochID, r.CompletedEpochIdentifier),
-			sdk.NewAttribute(delegationtype.AttributeKeyCompletedEpochNumber, fmt.Sprintf("%d", r.CompletedEpochNumber)),
-			sdk.NewAttribute(delegationtype.AttributeKeyUndelegationID, fmt.Sprintf("%d", r.UndelegationId)),
-			sdk.NewAttribute(delegationtype.AttributeKeyTxHash, params.TxHash.String()),
-			sdk.NewAttribute(delegationtype.AttributeKeyBlockNumber, fmt.Sprintf("%d", r.BlockNumber)),
-			sdk.NewAttribute(delegationtype.InstantUnbonding, fmt.Sprintf("%t", true)),
-		),
-	)
-
-	return k.Hooks().AfterUndelegationStarted(ctx, params.OperatorAddress, recordKey)
-}
-
-// UndelegateFrom handles normal undelegation with a waiting period.
-// UndelegateFrom: The undelegation needs to consider whether the operator's opted-in assets can exit from the AVS.
+// UndelegateFrom handles normal and instant undelegation.
+// The undelegation needs to consider whether the operator's opted-in assets can exit from the AVS.
 // Because only after the operator has served the AVS can the staking asset be undelegated.
 // So we use two steps to handle the undelegation. Fist,record the undelegation request and the corresponding exit time which needs to be obtained from the operator opt-in module. Then,we handle the record when the exit time has expired.
 func (k *Keeper) UndelegateFrom(ctx sdk.Context, params *delegationtype.DelegationOrUndelegationParams) error {
@@ -265,10 +170,29 @@ func (k *Keeper) UndelegateFrom(ctx sdk.Context, params *delegationtype.Delegati
 		Amount:                removeToken,
 		ActualCompletedAmount: removeToken,
 	}
-	completedEpochID, completedEpochNumber, err := k.operatorKeeper.GetUnbondingExpiration(ctx, params.OperatorAddress)
-	if err != nil {
-		return err
+
+	var completedEpochID string
+	var completedEpochNumber int64
+	var applySlash bool
+	if params.InstantUnbonding {
+		applySlash, completedEpochID, completedEpochNumber, err = k.operatorKeeper.GetInstantUnbondingExpiration(ctx, params.OperatorAddress)
+		if err != nil {
+			return err
+		}
+		// Apply instant penalty
+		if applySlash {
+			// Get the instant undelegation penalty
+			penalty := k.GetInstantUndelegationPenalty(ctx)
+			penaltyAmount := params.OpAmount.Mul(sdk.NewInt(int64(penalty))).Quo(sdk.NewInt(100))
+			r.ActualCompletedAmount = r.ActualCompletedAmount.Sub(penaltyAmount)
+		}
+	} else {
+		completedEpochID, completedEpochNumber, _, err = k.operatorKeeper.GetUnbondingExpiration(ctx, params.OperatorAddress)
+		if err != nil {
+			return err
+		}
 	}
+
 	r.CompletedEpochIdentifier = completedEpochID
 	r.CompletedEpochNumber = completedEpochNumber
 	// the hold count is relevant to async AVSs instead of sync AVSs. for example, the dogfood AVS is sync since it
@@ -307,6 +231,8 @@ func (k *Keeper) UndelegateFrom(ctx sdk.Context, params *delegationtype.Delegati
 			sdk.NewAttribute(delegationtype.AttributeKeyUndelegationID, fmt.Sprintf("%d", r.UndelegationId)),
 			sdk.NewAttribute(delegationtype.AttributeKeyTxHash, params.TxHash.String()),
 			sdk.NewAttribute(delegationtype.AttributeKeyBlockNumber, fmt.Sprintf("%d", r.BlockNumber)),
+			sdk.NewAttribute(delegationtype.AttributeKeyInstantUnbonding, fmt.Sprintf("%t", params.InstantUnbonding)),
+			sdk.NewAttribute(delegationtype.AttributeKeyApplyInstantSlash, fmt.Sprintf("%t", applySlash)),
 		),
 	)
 

--- a/x/delegation/keeper/msg_server.go
+++ b/x/delegation/keeper/msg_server.go
@@ -73,21 +73,13 @@ func (k *Keeper) UndelegateAssetFromOperator(
 	combined := fmt.Sprintf("%s-%d", txHash, nonce)
 	uniqueHash := sha256.Sum256([]byte(combined))
 
-	instantUnbonding := msg.InstantUnbonding
 	inputParamsList := newDelegationOrUndelegationParams(
-		msg.BaseInfo, assetstypes.ImuachainAssetAddr, assetstypes.ImuachainLzID, uniqueHash, instantUnbonding,
+		msg.BaseInfo, assetstypes.ImuachainAssetAddr, assetstypes.ImuachainLzID, uniqueHash, msg.InstantUnbonding,
 	)
 	cachedCtx, writeFunc := ctx.CacheContext()
 	for _, inputParams := range inputParamsList {
-		// Get instant unbonding flag from the message
-		if instantUnbonding {
-			if err := k.InstantUndelegateFrom(cachedCtx, inputParams); err != nil {
-				return nil, err
-			}
-		} else {
-			if err := k.UndelegateFrom(cachedCtx, inputParams); err != nil {
-				return nil, err
-			}
+		if err := k.UndelegateFrom(cachedCtx, inputParams); err != nil {
+			return nil, err
 		}
 	}
 	writeFunc()

--- a/x/delegation/types/events.go
+++ b/x/delegation/types/events.go
@@ -31,6 +31,8 @@ const (
 	AttributeKeyUndelegationID       = "undelegation_id"
 	AttributeKeyTxHash               = "tx_hash"
 	AttributeKeyBlockNumber          = "block_number"
+	AttributeKeyInstantUnbonding     = "instant_unbonding"
+	AttributeKeyApplyInstantSlash    = "apply_instant_slash"
 
 	// undelegation matured
 	EventTypeUndelegationMatured          = "undelegation_matured"
@@ -40,7 +42,4 @@ const (
 	// undelegation held back or released
 	EventTypeUndelegationHoldCountChanged = "undelegation_hold_count_changed"
 	AttributeKeyHoldCount                 = "hold_count"
-
-	// instant unbonding
-	InstantUnbonding = "instant_unbonding"
 )

--- a/x/delegation/types/expected_keepers.go
+++ b/x/delegation/types/expected_keepers.go
@@ -38,7 +38,8 @@ type DelegationHooks interface {
 
 type OperatorKeeper interface {
 	IsOperator(ctx sdk.Context, addr sdk.AccAddress) bool
-	GetUnbondingExpiration(ctx sdk.Context, operator sdk.AccAddress) (string, int64, error)
+	GetUnbondingExpiration(ctx sdk.Context, operator sdk.AccAddress) (string, int64, uint64, error)
+	GetInstantUnbondingExpiration(ctx sdk.Context, operator sdk.AccAddress) (bool, string, int64, error)
 }
 
 type AssetsKeeper interface {

--- a/x/delegation/types/genesis.go
+++ b/x/delegation/types/genesis.go
@@ -17,12 +17,14 @@ import (
 
 // NewGenesis returns a new genesis state with the given inputs.
 func NewGenesis(
+	params Params,
 	associations []StakerToOperator,
 	delegationStates []DelegationStates,
 	stakersByOperator []StakersByOperator,
 	undelegations []UndelegationAndHoldCount,
 ) *GenesisState {
 	return &GenesisState{
+		Params:            params,
 		Associations:      associations,
 		DelegationStates:  delegationStates,
 		StakersByOperator: stakersByOperator,
@@ -32,7 +34,7 @@ func NewGenesis(
 
 // DefaultGenesis returns the default genesis state
 func DefaultGenesis() *GenesisState {
-	return NewGenesis(nil, nil, nil, nil)
+	return NewGenesis(DefaultParams(), nil, nil, nil, nil)
 }
 
 func ValidateIDAndOperator(stakerID, assetID, operator string) error {
@@ -274,6 +276,10 @@ func (gs GenesisState) Validate() error {
 		return err
 	}
 	err = gs.ValidateUndelegations()
+	if err != nil {
+		return err
+	}
+	err = gs.Params.Validate()
 	if err != nil {
 		return err
 	}

--- a/x/delegation/types/genesis_test.go
+++ b/x/delegation/types/genesis_test.go
@@ -67,12 +67,12 @@ func (suite *GenesisTestSuite) TestValidateGenesis() {
 		},
 		{
 			name:     "base, should pass",
-			genState: types.NewGenesis(nil, delegationStates, stakersByOperator, nil),
+			genState: types.NewGenesis(types.DefaultParams(), nil, delegationStates, stakersByOperator, nil),
 			expPass:  true,
 		},
 		{
 			name:     "invalid staker id",
-			genState: types.NewGenesis(nil, delegationStates, stakersByOperator, nil),
+			genState: types.NewGenesis(types.DefaultParams(), nil, delegationStates, stakersByOperator, nil),
 			expPass:  false,
 			malleate: func(gs *types.GenesisState) {
 				invalidStateKey := assetstypes.GetJoinedStoreKey("invalid", assetID, operatorAddress.String())
@@ -84,7 +84,7 @@ func (suite *GenesisTestSuite) TestValidateGenesis() {
 		},
 		{
 			name:     "duplicate state key",
-			genState: types.NewGenesis(nil, delegationStates, stakersByOperator, nil),
+			genState: types.NewGenesis(types.DefaultParams(), nil, delegationStates, stakersByOperator, nil),
 			expPass:  false,
 			malleate: func(gs *types.GenesisState) {
 				gs.DelegationStates = append(gs.DelegationStates, gs.DelegationStates[0])
@@ -95,7 +95,7 @@ func (suite *GenesisTestSuite) TestValidateGenesis() {
 		},
 		{
 			name:     "invalid asset id",
-			genState: types.NewGenesis(nil, delegationStates, stakersByOperator, nil),
+			genState: types.NewGenesis(types.DefaultParams(), nil, delegationStates, stakersByOperator, nil),
 			expPass:  false,
 			malleate: func(gs *types.GenesisState) {
 				invalidStateKey := assetstypes.GetJoinedStoreKey(stakerID, "invalid", operatorAddress.String())
@@ -107,7 +107,7 @@ func (suite *GenesisTestSuite) TestValidateGenesis() {
 		},
 		{
 			name:     "asset id mismatch",
-			genState: types.NewGenesis(nil, delegationStates, stakersByOperator, nil),
+			genState: types.NewGenesis(types.DefaultParams(), nil, delegationStates, stakersByOperator, nil),
 			expPass:  false,
 			malleate: func(gs *types.GenesisState) {
 				stakerID, _ := assetstypes.GetStakerIDAndAssetID(
@@ -122,7 +122,7 @@ func (suite *GenesisTestSuite) TestValidateGenesis() {
 		},
 		{
 			name:     "nil wrapped undelegatable share",
-			genState: types.NewGenesis(nil, delegationStates, stakersByOperator, nil),
+			genState: types.NewGenesis(types.DefaultParams(), nil, delegationStates, stakersByOperator, nil),
 			expPass:  false,
 			malleate: func(gs *types.GenesisState) {
 				gs.DelegationStates[0].States.UndelegatableShare = math.LegacyDec{}
@@ -133,7 +133,7 @@ func (suite *GenesisTestSuite) TestValidateGenesis() {
 		},
 		{
 			name:     "nil wrapped unbonding amount",
-			genState: types.NewGenesis(nil, delegationStates, stakersByOperator, nil),
+			genState: types.NewGenesis(types.DefaultParams(), nil, delegationStates, stakersByOperator, nil),
 			expPass:  false,
 			malleate: func(gs *types.GenesisState) {
 				gs.DelegationStates[0].States.WaitUndelegationAmount = math.Int{}
@@ -144,7 +144,7 @@ func (suite *GenesisTestSuite) TestValidateGenesis() {
 		},
 		{
 			name:     "negative wrapped undelegatable share",
-			genState: types.NewGenesis(nil, delegationStates, stakersByOperator, nil),
+			genState: types.NewGenesis(types.DefaultParams(), nil, delegationStates, stakersByOperator, nil),
 			expPass:  false,
 			malleate: func(gs *types.GenesisState) {
 				gs.DelegationStates[0].States.UndelegatableShare = math.LegacyNewDec(-1)
@@ -155,7 +155,7 @@ func (suite *GenesisTestSuite) TestValidateGenesis() {
 		},
 		{
 			name:     "invalid operator address",
-			genState: types.NewGenesis(nil, delegationStates, stakersByOperator, nil),
+			genState: types.NewGenesis(types.DefaultParams(), nil, delegationStates, stakersByOperator, nil),
 			expPass:  false,
 			malleate: func(gs *types.GenesisState) {
 				invalidStateKey := assetstypes.GetJoinedStoreKey(stakerID, assetID, "invalid")
@@ -167,7 +167,7 @@ func (suite *GenesisTestSuite) TestValidateGenesis() {
 		},
 		{
 			name:     "duplicate stakerID in associations",
-			genState: types.NewGenesis(nil, delegationStates, stakersByOperator, nil),
+			genState: types.NewGenesis(types.DefaultParams(), nil, delegationStates, stakersByOperator, nil),
 			expPass:  false,
 			malleate: func(gs *types.GenesisState) {
 				gs.Associations = make([]types.StakerToOperator, 2)
@@ -182,7 +182,7 @@ func (suite *GenesisTestSuite) TestValidateGenesis() {
 		},
 		{
 			name:     "one stakerID in associations",
-			genState: types.NewGenesis(nil, delegationStates, stakersByOperator, nil),
+			genState: types.NewGenesis(types.DefaultParams(), nil, delegationStates, stakersByOperator, nil),
 			expPass:  true,
 			malleate: func(gs *types.GenesisState) {
 				gs.Associations = make([]types.StakerToOperator, 1)

--- a/x/delegation/types/msg.go
+++ b/x/delegation/types/msg.go
@@ -64,7 +64,7 @@ func (m *MsgUndelegation) GetSignBytes() []byte {
 }
 
 // new message to delegate asset to operator
-func NewMsgUndelegation(assetID, fromAddress string, amountPerOperator []KeyValue) *MsgUndelegation {
+func NewMsgUndelegation(instantUnbonding bool, assetID, fromAddress string, amountPerOperator []KeyValue) *MsgUndelegation {
 	baseInfo := &DelegationIncOrDecInfo{
 		FromAddress:        fromAddress,
 		PerOperatorAmounts: make([]KeyValue, 0, 1),
@@ -76,8 +76,9 @@ func NewMsgUndelegation(assetID, fromAddress string, amountPerOperator []KeyValu
 		)
 	}
 	return &MsgUndelegation{
-		AssetId:  assetID,
-		BaseInfo: baseInfo,
+		AssetId:          assetID,
+		BaseInfo:         baseInfo,
+		InstantUnbonding: instantUnbonding,
 	}
 }
 

--- a/x/delegation/types/params.go
+++ b/x/delegation/types/params.go
@@ -4,6 +4,20 @@ import (
 	errorsmod "cosmossdk.io/errors"
 )
 
+const DefaultInstantUnbondingPenalty = uint32(25)
+
+// NewParams creates a new Params instance.
+func NewParams(instantUnbondingPenalty uint32) Params {
+	return Params{
+		InstantUndelegationPenalty: instantUnbondingPenalty,
+	}
+}
+
+// DefaultParams returns a default set of parameters.
+func DefaultParams() Params {
+	return NewParams(DefaultInstantUnbondingPenalty)
+}
+
 func (p Params) Validate() error {
 	if p.InstantUndelegationPenalty > 100 {
 		return errorsmod.Wrap(ErrInvalidParams, "instant undelegation penalty cannot be greater than 100")

--- a/x/dogfood/keeper/impl_delegation_hooks.go
+++ b/x/dogfood/keeper/impl_delegation_hooks.go
@@ -31,11 +31,11 @@ func (wrapper DelegationHooksWrapper) AfterDelegation(
 
 // AfterUndelegationStarted is called after an undelegation is started.
 func (wrapper DelegationHooksWrapper) AfterUndelegationStarted(
-	ctx sdk.Context, operator sdk.AccAddress, recordKey []byte,
+	_ sdk.Context, _ sdk.AccAddress, _ []byte,
 ) error {
 	// Do nothing here because the `GetUnbondingExpiration` function can now
 	// calculate the correct unbonding duration, even for opt-out cases;
 	// therefore, the dogfood module doesn't need to manage the completion of undelegations.
-	// todo: Does the whole hook file and the related code also need to be removed?
+	// todo: remove the whole hook file and the related code in the future?
 	return nil
 }

--- a/x/dogfood/keeper/impl_delegation_hooks.go
+++ b/x/dogfood/keeper/impl_delegation_hooks.go
@@ -1,11 +1,7 @@
 package keeper
 
 import (
-	"fmt"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	keytypes "github.com/imua-xyz/imuachain/types/keys"
-	avstypes "github.com/imua-xyz/imuachain/x/avs/types"
 	delegationtypes "github.com/imua-xyz/imuachain/x/delegation/types"
 )
 
@@ -37,64 +33,9 @@ func (wrapper DelegationHooksWrapper) AfterDelegation(
 func (wrapper DelegationHooksWrapper) AfterUndelegationStarted(
 	ctx sdk.Context, operator sdk.AccAddress, recordKey []byte,
 ) error {
-	chainIDWithoutRevision := avstypes.ChainIDWithoutRevision(ctx.ChainID())
-	var unbondingCompletionEpoch int64
-	if wrapper.keeper.operatorKeeper.IsOperatorRemovingKeyFromChainID(
-		ctx, operator, chainIDWithoutRevision,
-	) {
-		// if the operator is opting out, we need to use the finish epoch of the opt out.
-		unbondingCompletionEpoch = wrapper.keeper.GetOperatorOptOutFinishEpoch(ctx, operator)
-		// even if the operator opts back in, the undelegated vote power does not reappear
-		// in the picture. slashable events between undelegation and opt in cannot occur
-		// because the operator is not in the validator set.
-	} else {
-		var found bool
-		var wrappedKey keytypes.WrappedConsKey
-		if found, wrappedKey, _ = wrapper.keeper.operatorKeeper.GetOperatorConsKeyForChainID(
-			ctx, operator, chainIDWithoutRevision,
-		); !found {
-			wrapper.keeper.Logger(ctx).Debug(
-				"AfterUndelegationStarted: operator is not opted in; ignoring",
-				"operator", operator,
-				"recordKey", fmt.Sprintf("%x", recordKey),
-			)
-			// if the operator has no key set, they are not opted in to this AVS. hence,
-			// we do not need to track the undelegation.
-			return nil
-		}
-		// check if the key is active yet
-		isValidator := false
-		_, isValidator = wrapper.keeper.GetImuachainValidator(
-			ctx, wrappedKey.ToConsAddr(),
-		)
-		if !isValidator {
-			// maybe they changed the key. check the previous key.
-			hasOldKey, prevKey, _ := wrapper.keeper.operatorKeeper.GetOperatorPrevConsKeyForChainID(
-				ctx, operator, chainIDWithoutRevision,
-			)
-			if hasOldKey {
-				_, isValidator = wrapper.keeper.GetImuachainValidator(
-					ctx, prevKey.ToConsAddr(),
-				)
-			}
-		}
-		if !isValidator {
-			wrapper.keeper.Logger(ctx).Debug(
-				"AfterUndelegationStarted: operator not yet a validator; ignoring",
-				"operator", operator,
-				"recordKey", fmt.Sprintf("%x", recordKey),
-			)
-			// if the key is not active, we do not need to track the undelegation.
-			// this can happen, for example, if the operator just opted into
-			// the AVS and the epoch hasn't yet ended.
-			return nil
-		}
-		// otherwise, we use the default unbonding completion epoch.
-		unbondingCompletionEpoch = wrapper.keeper.GetUnbondingCompletionEpoch(ctx)
-		// if the operator opts out after this, the undelegation will mature before the opt out.
-		// so this is not a concern.
-	}
-	wrapper.keeper.AppendUndelegationToMature(ctx, unbondingCompletionEpoch, recordKey)
-	wrapper.keeper.SetUndelegationMaturityEpoch(ctx, recordKey, unbondingCompletionEpoch)
-	return wrapper.keeper.delegationKeeper.IncrementUndelegationHoldCount(ctx, recordKey)
+	// Do nothing here because the `GetUnbondingExpiration` function can now
+	// calculate the correct unbonding duration, even for opt-out cases;
+	// therefore, the dogfood module doesn't need to manage the completion of undelegations.
+	// todo: Does the whole hook file and the related code also need to be removed?
+	return nil
 }

--- a/x/dogfood/keeper/unbonding_test.go
+++ b/x/dogfood/keeper/unbonding_test.go
@@ -100,7 +100,7 @@ func (suite *KeeperTestSuite) TestUndelegations() {
 	epochsUntilUnbonded := suite.App.StakingKeeper.GetEpochsUntilUnbonded(suite.Ctx)
 	for i := 0; i < int(epochsUntilUnbonded); i++ {
 		suite.Equal(
-			uint64(1), suite.App.DelegationKeeper.GetUndelegationHoldCount(suite.Ctx, recordKey),
+			uint64(0), suite.App.DelegationKeeper.GetUndelegationHoldCount(suite.Ctx, recordKey),
 		)
 		suite.CheckLengthOfValidatorUpdates(0, nil, "moving forward one epoch")
 	}
@@ -140,7 +140,7 @@ func (suite *KeeperTestSuite) TestUndelegations() {
 	// early release, based on the opt out epoch
 	for i := 0; i < int(epochsUntilUnbonded)-forwardEpochs; i++ {
 		suite.Equal(
-			uint64(1), suite.App.DelegationKeeper.GetUndelegationHoldCount(suite.Ctx, recordKey),
+			uint64(0), suite.App.DelegationKeeper.GetUndelegationHoldCount(suite.Ctx, recordKey),
 		)
 		suite.CheckLengthOfValidatorUpdates(0, nil, "moving forward one epoch")
 	}
@@ -272,7 +272,7 @@ func (suite *KeeperTestSuite) TestUndelegationEdgeCases() {
 		uint64(suite.Ctx.BlockHeight()), initialUndelegationID+2, txHash.String(), operatorAddressString,
 	)
 	suite.Equal(
-		uint64(1), suite.App.DelegationKeeper.GetUndelegationHoldCount(suite.Ctx, recordKey),
+		uint64(0), suite.App.DelegationKeeper.GetUndelegationHoldCount(suite.Ctx, recordKey),
 	)
 	suite.CheckLengthOfValidatorUpdates(1, []int64{amountUSD * 2}, "undelegate")
 	// replace the key
@@ -302,7 +302,7 @@ func (suite *KeeperTestSuite) TestUndelegationEdgeCases() {
 		uint64(suite.Ctx.BlockHeight()), initialUndelegationID+3, txHash.String(), operatorAddressString,
 	)
 	suite.Equal(
-		uint64(1), suite.App.DelegationKeeper.GetUndelegationHoldCount(suite.Ctx, recordKey),
+		uint64(0), suite.App.DelegationKeeper.GetUndelegationHoldCount(suite.Ctx, recordKey),
 	)
 	suite.CheckLengthOfValidatorUpdates(2, []int64{amountUSD * 1, 0}, "replace key")
 }

--- a/x/operator/keeper/keeper.go
+++ b/x/operator/keeper/keeper.go
@@ -61,7 +61,7 @@ type OperatorKeeper interface {
 
 	IsOperator(ctx sdk.Context, addr sdk.AccAddress) bool
 
-	GetUnbondingExpiration(ctx sdk.Context, operator sdk.AccAddress) (string, int64, error)
+	GetUnbondingExpiration(ctx sdk.Context, operator sdk.AccAddress) (string, int64, uint64, error)
 
 	GetInstantUnbondingExpiration(ctx sdk.Context, operator sdk.AccAddress) (bool, string, int64, error)
 

--- a/x/operator/keeper/keeper.go
+++ b/x/operator/keeper/keeper.go
@@ -63,6 +63,8 @@ type OperatorKeeper interface {
 
 	GetUnbondingExpiration(ctx sdk.Context, operator sdk.AccAddress) (string, int64, error)
 
+	GetInstantUnbondingExpiration(ctx sdk.Context, operator sdk.AccAddress) (bool, string, int64, error)
+
 	OptIn(ctx sdk.Context, operatorAddress sdk.AccAddress, AVSAddr string) error
 
 	OptOut(ctx sdk.Context, OperatorAddress sdk.AccAddress, AVSAddr string) error

--- a/x/operator/keeper/operator.go
+++ b/x/operator/keeper/operator.go
@@ -314,11 +314,11 @@ func (k *Keeper) GetImpactfulAVSForOperator(ctx sdk.Context, operatorAddr string
 	return avsList, nil
 }
 
-func (k Keeper) GetUnbondingExpiration(ctx sdk.Context, operator sdk.AccAddress) (string, int64, error) {
+func (k Keeper) GetUnbondingExpiration(ctx sdk.Context, operator sdk.AccAddress) (string, int64, uint64, error) {
 	// get the impactful AVSs for the operator
 	avsList, err := k.GetImpactfulAVSForOperator(ctx, operator.String())
 	if err != nil {
-		return "", 0, err
+		return "", 0, 0, err
 	}
 	// calculate the maximum unbonding expiration
 	// Using self-definied NullEpochIdentifier and NullEpochNumber as the default unbonding expiration.
@@ -328,30 +328,95 @@ func (k Keeper) GetUnbondingExpiration(ctx sdk.Context, operator sdk.AccAddress)
 	for _, avs := range avsList {
 		epochInfo, err := k.avsKeeper.GetAVSEpochInfo(ctx, avs.AVSAddr)
 		if err != nil {
-			return "", 0, err
+			return "", 0, 0, err
 		}
 		unbondingDuration, err := k.avsKeeper.GetAVSUnbondingDuration(ctx, avs.AVSAddr)
 		if err != nil {
-			return "", 0, err
+			return "", 0, 0, err
 		}
 		if avs.HasOptedOut {
 			unbondingDuration = avs.OptOutUnbondingRemaining
 		}
 		if unbondingDuration+uint64(epochInfo.CurrentEpoch) > uint64(math.MaxInt64) {
-			return "", 0, xerrors.New("the sum of unbondingDuration and the current epoch number exceeds the int64 range.")
+			return "", 0, 0, xerrors.New("the sum of unbondingDuration and the current epoch number exceeds the int64 range.")
 		}
-		durationSeconds := unbondingDuration * uint64(epochInfo.Duration)
-		// address the case that the unbonding time is the end of current epoch.
-		if unbondingDuration == 0 {
-			durationSeconds = uint64(epochInfo.CurrentEpochStartTime.Add(epochInfo.Duration).Sub(ctx.BlockTime()))
-		}
-		if durationSeconds > maxDurationSeconds {
+
+		remainingTimeForCurrentEpoch := uint64(epochInfo.CurrentEpochStartTime.Add(epochInfo.Duration).Sub(ctx.BlockTime()))
+		unbondingDurationSeconds := unbondingDuration*uint64(epochInfo.Duration) + remainingTimeForCurrentEpoch
+		if unbondingDurationSeconds > maxDurationSeconds {
 			retEpochIdentifier = epochInfo.Identifier
 			retEpochNumber = epochInfo.CurrentEpoch + int64(unbondingDuration)
-			maxDurationSeconds = durationSeconds
+			maxDurationSeconds = unbondingDurationSeconds
 		}
 	}
-	return retEpochIdentifier, retEpochNumber, nil
+	return retEpochIdentifier, retEpochNumber, maxDurationSeconds, nil
+}
+
+// GetInstantUnbondingExpiration determines the correct epoch identifier to use for instant undelegations.
+// Instant undelegations are completed at the end of the current epoch, but since an operator might opt into
+// multiple AVSs with different epoch configurations, we must choose the appropriate epoch identifier carefully.
+//
+// Specifically, we select the epoch identifier with the longest remaining time in the current epoch.
+// This ensures that the undelegation completes after all other relevant epochs end, so that voting power updates
+// and reward distributions for the current epoch remain unaffected.
+//
+// For example, suppose the operator has opted into three AVSs with the following epoch identifiers and remaining times:
+//   - AVS1: minute (remaining: 20s)
+//   - AVS2: day (remaining: 7h)
+//   - AVS3: week (remaining: 6h)
+//
+// In this case, "day" should be chosen as the epoch identifier for the undelegation completion,
+// because it has the latest epoch end time among all related AVSs. The instant undelegation will be completed
+// in 7 hours, at the end of the current "day" epoch.
+// The returned epoch number will always correspond to the current epoch of the selected identifier.
+// The first return value indicates whether the calculated instant unbonding duration is less than
+// the non-instant unbonding duration. This value can be used to determine whether a slash should be
+// applied for the submitted instant undelegation.
+func (k Keeper) GetInstantUnbondingExpiration(ctx sdk.Context, operator sdk.AccAddress) (bool, string, int64, error) {
+	// get the impactful AVSs for the operator
+	avsList, err := k.GetImpactfulAVSForOperator(ctx, operator.String())
+	if err != nil {
+		return false, "", 0, err
+	}
+
+	// calculate the maximum instant unbonding expiration
+	// Using self-definied NullEpochIdentifier and NullEpochNumber as the default unbonding expiration.
+	instantEpochIdentifier := epochtypes.NullEpochIdentifier
+	instantEpochNumber := epochtypes.NullEpochNumber
+	maxRemainingTime := uint64(0)
+	handledEpochMap := make(map[string]interface{})
+	for _, avs := range avsList {
+		epochInfo, err := k.avsKeeper.GetAVSEpochInfo(ctx, avs.AVSAddr)
+		if err != nil {
+			return false, "", 0, err
+		}
+		if _, isHandled := handledEpochMap[epochInfo.Identifier]; !isHandled {
+			handledEpochMap[epochInfo.Identifier] = nil
+		} else {
+			continue
+		}
+
+		// calculate the remaining time of the current epoch
+		remainingTime := uint64(epochInfo.CurrentEpochStartTime.Add(epochInfo.Duration).Sub(ctx.BlockTime()))
+		if remainingTime > maxRemainingTime {
+			instantEpochIdentifier = epochInfo.Identifier
+			instantEpochNumber = epochInfo.CurrentEpoch
+			maxRemainingTime = remainingTime
+		}
+	}
+
+	// get the expiration for normal undelegation
+	normalUnbondingEpochID, normalUnbondingEpochNumber, unbondingDurationSec, err := k.GetUnbondingExpiration(ctx, operator)
+	if err != nil {
+		return false, "", 0, err
+	}
+
+	if maxRemainingTime < unbondingDurationSec {
+		// Use the chosen completion time and apply a slash for instant unbonding
+		// only if the calculated instant unbonding duration is shorter than the normal unbonding duration.
+		return true, instantEpochIdentifier, instantEpochNumber, nil
+	}
+	return false, normalUnbondingEpochID, normalUnbondingEpochNumber, nil
 }
 
 func (k *Keeper) SetAllOptedInfo(ctx sdk.Context, optedStates []operatortypes.OptedState) error {

--- a/x/operator/keeper/operator_info_test.go
+++ b/x/operator/keeper/operator_info_test.go
@@ -56,23 +56,25 @@ func (suite *OperatorTestSuite) TestAllOperators() {
 
 func (suite *OperatorTestSuite) TestGetUnbondingExpiration() {
 	suite.prepare()
-	epochIdentifier, epochNumber, err := suite.App.OperatorKeeper.GetUnbondingExpiration(suite.Ctx, suite.operatorAddr)
+	epochIdentifier, epochNumber, _, err := suite.App.OperatorKeeper.GetUnbondingExpiration(suite.Ctx, suite.operatorAddr)
 	suite.NoError(err)
 	suite.Equal(epochsTypes.NullEpochIdentifier, epochIdentifier)
 	suite.Equal(epochsTypes.NullEpochNumber, epochNumber)
 
 	// opts into multiple AVSs
 	testAVSNumber := 4
+	testAVSs := make([]string, 0)
 	for i := 0; i < testAVSNumber; i++ {
 		avsName := fmt.Sprintf("avsTestAddr_%d", i)
 		suite.prepareAvs(avsName, []string{usdtAssetID}, testutil.EpochsForTest[i], defaultUnbondingPeriod)
+		testAVSs = append(testAVSs, suite.avsAddr)
 		err = suite.App.OperatorKeeper.OptIn(suite.Ctx, suite.operatorAddr, suite.avsAddr)
 		suite.NoError(err)
 	}
 	weekEpochInfo, found := suite.App.EpochsKeeper.GetEpochInfo(suite.Ctx, epochsTypes.WeekEpochID)
 	suite.True(found)
 
-	epochIdentifier, epochNumber, err = suite.App.OperatorKeeper.GetUnbondingExpiration(suite.Ctx, suite.operatorAddr)
+	epochIdentifier, epochNumber, _, err = suite.App.OperatorKeeper.GetUnbondingExpiration(suite.Ctx, suite.operatorAddr)
 	suite.NoError(err)
 	suite.Equal(epochsTypes.WeekEpochID, epochIdentifier)
 	suite.Equal(uint64(weekEpochInfo.CurrentEpoch)+defaultUnbondingPeriod, uint64(epochNumber))
@@ -82,11 +84,12 @@ func (suite *OperatorTestSuite) TestGetUnbondingExpiration() {
 	minuteEpochInfo, found := suite.App.EpochsKeeper.GetEpochInfo(suite.Ctx, epochsTypes.MinuteEpochID)
 	suite.True(found)
 	avsName := fmt.Sprintf("avsTestAddr_%d", testAVSNumber+1)
-	minuteUnbondingPeriod := defaultUnbondingPeriod*uint64(weekEpochInfo.Duration.Milliseconds()/minuteEpochInfo.Duration.Milliseconds()) + 1
+	//  Adding 1 to defaultUnbondingPeriod is used to account for the current epoch.
+	minuteUnbondingPeriod := (defaultUnbondingPeriod+1)*uint64(weekEpochInfo.Duration.Milliseconds()/minuteEpochInfo.Duration.Milliseconds()) + 1
 	suite.prepareAvs(avsName, []string{usdtAssetID}, epochsTypes.MinuteEpochID, minuteUnbondingPeriod)
 	err = suite.App.OperatorKeeper.OptIn(suite.Ctx, suite.operatorAddr, suite.avsAddr)
 	suite.NoError(err)
-	epochIdentifier, epochNumber, err = suite.App.OperatorKeeper.GetUnbondingExpiration(suite.Ctx, suite.operatorAddr)
+	epochIdentifier, epochNumber, _, err = suite.App.OperatorKeeper.GetUnbondingExpiration(suite.Ctx, suite.operatorAddr)
 	suite.NoError(err)
 	suite.Equal(epochsTypes.MinuteEpochID, epochIdentifier)
 	suite.Equal(uint64(minuteEpochInfo.CurrentEpoch)+minuteUnbondingPeriod, uint64(epochNumber))
@@ -94,7 +97,7 @@ func (suite *OperatorTestSuite) TestGetUnbondingExpiration() {
 	// test the case where the operator opts in and out at same epoch
 	err = suite.App.OperatorKeeper.OptOut(suite.Ctx, suite.operatorAddr, suite.avsAddr)
 	suite.NoError(err)
-	epochIdentifier, epochNumber, err = suite.App.OperatorKeeper.GetUnbondingExpiration(suite.Ctx, suite.operatorAddr)
+	epochIdentifier, epochNumber, _, err = suite.App.OperatorKeeper.GetUnbondingExpiration(suite.Ctx, suite.operatorAddr)
 	suite.NoError(err)
 	suite.Equal(epochsTypes.WeekEpochID, epochIdentifier)
 	suite.Equal(uint64(weekEpochInfo.CurrentEpoch)+defaultUnbondingPeriod, uint64(epochNumber))
@@ -105,7 +108,7 @@ func (suite *OperatorTestSuite) TestGetUnbondingExpiration() {
 	suite.CommitAfter(time.Minute + time.Nanosecond)
 	err = suite.App.OperatorKeeper.OptOut(suite.Ctx, suite.operatorAddr, suite.avsAddr)
 	suite.NoError(err)
-	epochIdentifier, epochNumber, err = suite.App.OperatorKeeper.GetUnbondingExpiration(suite.Ctx, suite.operatorAddr)
+	epochIdentifier, epochNumber, _, err = suite.App.OperatorKeeper.GetUnbondingExpiration(suite.Ctx, suite.operatorAddr)
 	suite.NoError(err)
 	suite.Equal(epochsTypes.MinuteEpochID, epochIdentifier)
 	minuteEpochInfo, found = suite.App.EpochsKeeper.GetEpochInfo(suite.Ctx, epochsTypes.MinuteEpochID)
@@ -114,18 +117,25 @@ func (suite *OperatorTestSuite) TestGetUnbondingExpiration() {
 
 	// test the case where the operator has opted out for a period, then it's unbonding duration won't be
 	// the maximum value.
-	err = suite.App.OperatorKeeper.OptIn(suite.Ctx, suite.operatorAddr, suite.avsAddr)
+	// register another operator and opts into the AVS2(day) and AVS3(week) for this case
+	suite.prepareOperator()
+	err = suite.App.OperatorKeeper.OptIn(suite.Ctx, suite.operatorAddr, testAVSs[2])
 	suite.NoError(err)
-	suite.CommitAfter(time.Minute + time.Nanosecond)
-	err = suite.App.OperatorKeeper.OptOut(suite.Ctx, suite.operatorAddr, suite.avsAddr)
+	err = suite.App.OperatorKeeper.OptIn(suite.Ctx, suite.operatorAddr, testAVSs[3])
 	suite.NoError(err)
-	suite.CommitAfter(2*time.Minute + time.Nanosecond)
-	epochIdentifier, epochNumber, err = suite.App.OperatorKeeper.GetUnbondingExpiration(suite.Ctx, suite.operatorAddr)
+	suite.CommitAfter(time.Hour*24 + time.Nanosecond)
+	err = suite.App.OperatorKeeper.OptOut(suite.Ctx, suite.operatorAddr, testAVSs[3])
 	suite.NoError(err)
-	suite.Equal(epochsTypes.WeekEpochID, epochIdentifier)
-	weekEpochInfo, found = suite.App.EpochsKeeper.GetEpochInfo(suite.Ctx, epochsTypes.WeekEpochID)
+	runBlockNumber := (defaultUnbondingPeriod + 1) * 7
+	for i := uint64(0); i < runBlockNumber; i++ {
+		suite.NextBlock()
+	}
+	epochIdentifier, epochNumber, _, err = suite.App.OperatorKeeper.GetUnbondingExpiration(suite.Ctx, suite.operatorAddr)
+	suite.NoError(err)
+	suite.Equal(epochsTypes.DayEpochID, epochIdentifier)
+	dayEpochInfo, found := suite.App.EpochsKeeper.GetEpochInfo(suite.Ctx, epochsTypes.DayEpochID)
 	suite.True(found)
-	suite.Equal(uint64(weekEpochInfo.CurrentEpoch)+defaultUnbondingPeriod, uint64(epochNumber))
+	suite.Equal(uint64(dayEpochInfo.CurrentEpoch)+defaultUnbondingPeriod, uint64(epochNumber))
 }
 
 // TODO: enable this test when editing operator is implemented. allow for querying

--- a/x/operator/keeper/opt_test.go
+++ b/x/operator/keeper/opt_test.go
@@ -41,7 +41,7 @@ func (suite *OperatorTestSuite) registerOperator(operator string) {
 }
 
 func (suite *OperatorTestSuite) prepareOperator() {
-	suite.operatorAddr = sdk.AccAddress(testutiltx.GenerateAddress().Bytes())
+	suite.operatorAddr = testutiltx.GenerateAddress().Bytes()
 	// register operator
 	suite.registerOperator(suite.operatorAddr.String())
 }

--- a/x/operator/keeper/slash_test.go
+++ b/x/operator/keeper/slash_test.go
@@ -57,7 +57,7 @@ func (suite *OperatorTestSuite) TestSlashWithInfractionReason() {
 	undelegationAmount := sdkmath.NewIntWithDecimal(10, assetDecimal)
 	suite.prepareDelegation(false, suite.Address, suite.assetAddr, suite.operatorAddr, undelegationAmount)
 	delegationRemaining := delegationAmount.Add(newDelegateAmount).Sub(undelegationAmount)
-	completedEpochId, completedEpochNumber, err := suite.App.OperatorKeeper.GetUnbondingExpiration(suite.Ctx, suite.operatorAddr)
+	completedEpochId, completedEpochNumber, _, err := suite.App.OperatorKeeper.GetUnbondingExpiration(suite.Ctx, suite.operatorAddr)
 	suite.NoError(err)
 	epochInfo, found := suite.App.EpochsKeeper.GetEpochInfo(suite.Ctx, completedEpochId)
 	suite.True(found)


### PR DESCRIPTION
## Description

This PR fixes some issues and refines the implementation for instant unbonding.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for instant undelegation with an optional instant unbonding flag.
  - Undelegation events now report instant unbonding and instant slashing status.

- **Improvements**
  - CLI command updated to include an instant unbonding flag for undelegation.
  - Enhanced error messages for undelegation parameter validation.
  - Refined unbonding expiration calculations to improve accuracy.
  - Delegation module genesis now includes default parameters for better configuration.

- **Bug Fixes**
  - Updated test expectations for undelegation hold counts.

- **Developer Notes**
  - Consolidated undelegation logic to unify instant and normal undelegation flows.
  - Removed deprecated hooks and streamlined event attribute handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->