### PR TITLE
genesis(operator): disable the check for empty operator asset USD value temporarily

### DIFF
--- a/x/operator/keeper/usd_value.go
+++ b/x/operator/keeper/usd_value.go
@@ -539,7 +539,6 @@ func (k *Keeper) AggregateOperatorUSDValue(
 		// get the total USD value of asset
 		totalUSDValue, err := k.GetOperatorAssetUSDValue(ctx, epochIdentifier, operator, assetID)
 		if err != nil {
-			ctx.Logger().Error("AggregateOperatorUSDValue: failed to get the operator asset USD value", "err", err, "epochIdentifier", epochIdentifier, "operator", operator, "assetID", assetID)
 			// continue handling the other assets
 			continue
 		}

--- a/x/operator/types/genesis.go
+++ b/x/operator/types/genesis.go
@@ -503,9 +503,11 @@ func (gs GenesisState) ValidateOperatorKeyRemovals(operators map[string]struct{}
 }
 
 func (gs GenesisState) ValidateOperatorAssetUSDValues(operators map[string]struct{}) error {
-	if len(gs.OperatorUSDValues) != 0 && len(gs.OperatorAssetUsdValues) == 0 {
+	// TODO: The asset USD values might be empty during the testnet upgrade from V8 to V9.
+	// So this check is temporarily disabled. It will be enabled after the upgrade.
+	/*	if len(gs.OperatorUSDValues) != 0 && len(gs.OperatorAssetUsdValues) == 0 {
 		return ErrInvalidGenesisData.Wrap("ValidateOperatorAssetUSDValues: the USD value of the operator's asset can't be empty.")
-	}
+	}*/
 	validationFunc := func(_ int, usdValue OperatorAssetUSDValue) error {
 		stringList, err := assetstypes.ParseJoinedStoreKey([]byte(usdValue.Key), 3)
 		if err != nil {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Temporarily disabled a validation check to allow for empty asset USD values during the testnet upgrade from version 8 to 9. The check will be re-enabled after the upgrade.
  * Removed an error log to reduce noise during asset value aggregation without changing error handling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->