### PR TITLE
fix(avs): avoid npe during epoch hook

### DIFF
--- a/x/avs/keeper/impl_epoch_hook.go
+++ b/x/avs/keeper/impl_epoch_hook.go
@@ -77,6 +77,10 @@ func (wrapper EpochsHooksWrapper) AfterEpochEnd(
 				// Handle the error gracefully, continue to the next
 				// continue
 			}
+			if taskInfo == nil {
+				// The task didn't opt-in yet, skip
+				continue
+			}
 			diff := types.Difference(taskInfo.OptInOperators, signedOperatorList)
 			taskInfo.SignedOperators = signedOperatorList
 			// If a signature is submitted only once, it is counted as NoSignedOperators


### PR DESCRIPTION
```go
2:29PM ERR CONSENSUS FAILURE!!! err="runtime error: invalid memory address or nil pointer dereference" module=consensus server=node stack="goroutine 214 [running]:
runtime/debug.Stack()
  runtime/debug/stack.go:24 +0x5e
github.com/cometbft/cometbft/consensus.(*State).receiveRoutine.func2()
  github.com/cometbft/cometbft@v0.37.4/consensus/state.go:736 +0x46
panic({0x2f68460?, 0x6013c40?})
  runtime/panic.go:914 +0x21f
github.com/imua-xyz/imuachain/x/avs/keeper.EpochsHooksWrapper.AfterEpochEnd({_}, {{0x43f9bb0, 0x63b2f80}, {0x4416120, 0xc006103380}, {{0xb, 0x0}, {0xc002ce07e0, 0x17}, 0x1f0, ...}, ...}, ...)
  github.com/imua-xyz/imuachain/x/avs/keeper/impl_epoch_hook.go:80 +0x4f6
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability by handling cases where task information is unavailable, preventing potential errors during processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->