### PR TITLE
fix: permit 2 letter denoms in SDK

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"regexp"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/evmos/evmos/v16/types"
@@ -48,6 +50,14 @@ func SetBip44CoinType(config *sdk.Config) {
 
 // RegisterDenoms registers the base and display denominations to the SDK.
 func RegisterDenoms() {
+	// per https://github.com/cosmos/cosmos-sdk/pull/7998, we can use a custom function
+	// for validation of the denom.
+	sdk.SetCoinDenomRegex(func() string {
+		// do not add start and end anchors; they are added in `SetCoinDenomRegex`
+		reg := `[a-zA-Z][a-zA-Z0-9/:._-]{1,127}`
+		regexp.MustCompile(reg)
+		return reg
+	})
 	if err := sdk.RegisterDenom(DisplayDenom, sdk.OneDec()); err != nil {
 		panic(err)
 	}

--- a/local_node.sh
+++ b/local_node.sh
@@ -5,6 +5,10 @@ if [ -z "$ALCHEMY_API_KEY" ]; then
 	echo "ALCHEMY_API_KEY is not set"
 	exit 1
 fi
+if [ -z "$BOOTSTRAP" ]; then
+	echo "BOOTSTRAP is not set"
+	exit 1
+fi
 
 KEYS[0]="dev0"
 KEYS[1]="dev1"
@@ -175,9 +179,9 @@ if [[ $overwrite == "y" || $overwrite == "Y" ]]; then
 	jq '.app_state["operator"]["operators"][0]["operator_info"]["earnings_addr"]="'"$LOCAL_ADDRESS_IM"'"' "$GENESIS" >"$TMP_GENESIS" && mv "$TMP_GENESIS" "$GENESIS"
 	jq '.app_state["operator"]["operators"][0]["operator_info"]["approve_addr"]="'"$LOCAL_ADDRESS_IM"'"' "$GENESIS" >"$TMP_GENESIS" && mv "$TMP_GENESIS" "$GENESIS"
 	jq '.app_state["operator"]["operators"][0]["operator_info"]["operator_meta_info"]="operator1"' "$GENESIS" >"$TMP_GENESIS" && mv "$TMP_GENESIS" "$GENESIS"
-	jq '.app_state["operator"]["operators"][0]["operator_info"]["commission"]["commission_rates"]["rate"]="0.0"' "$GENESIS" >"$TMP_GENESIS" && mv "$TMP_GENESIS" "$GENESIS"
-	jq '.app_state["operator"]["operators"][0]["operator_info"]["commission"]["commission_rates"]["max_rate"]="0.0"' "$GENESIS" >"$TMP_GENESIS" && mv "$TMP_GENESIS" "$GENESIS"
-	jq '.app_state["operator"]["operators"][0]["operator_info"]["commission"]["commission_rates"]["max_change_rate"]="0.0"' "$GENESIS" >"$TMP_GENESIS" && mv "$TMP_GENESIS" "$GENESIS"
+	jq '.app_state["operator"]["operators"][0]["operator_info"]["commission"]["commission_rates"]["rate"]="0.05"' "$GENESIS" >"$TMP_GENESIS" && mv "$TMP_GENESIS" "$GENESIS"
+	jq '.app_state["operator"]["operators"][0]["operator_info"]["commission"]["commission_rates"]["max_rate"]="1.0"' "$GENESIS" >"$TMP_GENESIS" && mv "$TMP_GENESIS" "$GENESIS"
+	jq '.app_state["operator"]["operators"][0]["operator_info"]["commission"]["commission_rates"]["max_change_rate"]="0.1"' "$GENESIS" >"$TMP_GENESIS" && mv "$TMP_GENESIS" "$GENESIS"
 	jq '.app_state["operator"]["operator_records"][0]["operator_address"]="'"$LOCAL_ADDRESS_IM"'"' "$GENESIS" >"$TMP_GENESIS" && mv "$TMP_GENESIS" "$GENESIS"
 	jq '.app_state["operator"]["operator_records"][0]["chains"][0]["chain_id"]="'"$CHAINID_WITHOUT_REVISION"'"' "$GENESIS" >"$TMP_GENESIS" && mv "$TMP_GENESIS" "$GENESIS"
 	jq '.app_state["operator"]["operator_records"][0]["chains"][0]["consensus_key"]="'"$CONSENSUS_KEY"'"' "$GENESIS" >"$TMP_GENESIS" && mv "$TMP_GENESIS" "$GENESIS"


### PR DESCRIPTION
```
panic: invalid denom: IM

goroutine 1 [running]:
github.com/imua-xyz/imuachain/cmd/config.RegisterDenoms()
        github.com/imua-xyz/imuachain/cmd/config/config.go:52 +0x85
main.main()
        github.com/imua-xyz/imuachain/cmd/imuad/main.go:16 +0x18
```

fix(local): allow run
1. Change min commission and other params
2. Complain if BOOTSTRAP is not set


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Changes**
  * Enhanced denomination validation configuration
  * Added required environment variable check for deployment setup
  * Updated default commission rate parameters in genesis configuration

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->