### PR TITLE
fix(docker): drop apk version pins on Alpine 3.21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,10 @@ WORKDIR /go/src/github.com/imua-xyz/imuachain
 
 COPY go.mod go.sum ./
 
-RUN apk add --no-cache ca-certificates=~20250911 build-base=~0.5 git=~2.47.3 linux-headers=~6.6
+# Rely on the pinned Alpine 3.21 base image for reproducibility; fuzzy apk
+# pins break CI whenever the stable index advances within a release line.
+# hadolint ignore=DL3018
+RUN apk add --no-cache ca-certificates build-base git linux-headers
 
 RUN --mount=type=bind,target=. --mount=type=secret,id=GITHUB_TOKEN \
     git config --global url."https://$(cat /run/secrets/GITHUB_TOKEN)@github.com/".insteadOf "https://github.com/"; \
@@ -23,12 +26,15 @@ WORKDIR /root
 COPY --from=build-env /go/src/github.com/imua-xyz/imuachain/build/imuad /usr/bin/imuad
 COPY --from=build-env /go/bin/toml-cli /usr/bin/toml-cli
 
+# Rely on the pinned Alpine 3.21 base image for reproducibility; fuzzy apk
+# pins break CI whenever the stable index advances within a release line.
+# hadolint ignore=DL3018
 RUN apk add --no-cache \
-	ca-certificates=~20250911 \
-	libstdc++=~14.2.0 \
-	jq=~1.7.1 \
-	curl=~8.14.1 \
-	bash=~5.2.37 \
+	ca-certificates \
+	libstdc++ \
+	jq \
+	curl \
+	bash \
     && addgroup -g 1000 imua \
     && adduser -S -h /home/imua -D imua -u 1000 -G imua
 


### PR DESCRIPTION
## Problem

Alpine 3.21's stable index advances package versions between patch revisions (`ca-certificates` went `20250619` → `20250911` → `20260413` during this PR), which keeps breaking the fuzzy `apk add pkg=~X` pins in `Dockerfile` and blocking the `docker-build` CI job whenever apk can no longer satisfy a pin.

## Changes

- Drop the `=~X` apk version pins for every package in both build stages. Reproducibility is still provided by the pinned base images (`golang:1.23.11-alpine3.21`, `alpine:3.21`); Alpine keeps shipping security fixes within the 3.21 line automatically.
- Add a `# hadolint ignore=DL3018` directive directly above each `RUN apk add`, with a rationale comment, so super-linter's hadolint job accepts the intentional unpinning without DL3018 warnings.

## Test plan

- [x] `docker-build` job passes on the updated branch.
- [x] `run-super-linter` job passes (hadolint DL3018 no longer raised).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Relaxed package version constraints in the container build and runtime stages to allow flexible updates of base dependencies.
  * No changes to runtime behavior or user-facing features; existing user/group setup and package list remain intact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->